### PR TITLE
change job name guid to 5 chars

### DIFF
--- a/core/task-executor/lib/jobs/jobCreator.js
+++ b/core/task-executor/lib/jobs/jobCreator.js
@@ -53,7 +53,7 @@ const applyAlgorithmName = (inputSpec, algorithmName) => {
 
 const applyName = (inputSpec, algorithmName) => {
     const spec = clonedeep(inputSpec);
-    const name = `${algorithmName}-${randomString({ length: 30 })}`;
+    const name = `${algorithmName}-${randomString({ length: 5 })}`;
     spec.metadata.name = name;
     return spec;
 };


### PR DESCRIPTION
change guid (random string) of job name (for workers and pipeline-drivers) to 5 chars instead of 30
fixes #932

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-hpc/hkube/933)
<!-- Reviewable:end -->
