### PR TITLE
add force flag to kaniko to fix cgroups v2 issue

### DIFF
--- a/core/algorithm-builder/lib/builds/build-utils.sh
+++ b/core/algorithm-builder/lib/builds/build-utils.sh
@@ -125,6 +125,7 @@ dockerBuildKaniko() {
     --build-arg packagesToken=${packagesToken} \
     --build-arg baseImage=${baseImage} \
     --build-arg dependency_install_cmd=${dependency_install_cmd} \
+    --force \
     --destination $image" > ${commands}/run
   
   chmod +x ${commands}/run


### PR DESCRIPTION
add force flag to kaniko to fix cgroups v2 issue
see https://github.com/GoogleContainerTools/kaniko/issues/1592

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-hpc/hkube/1561)
<!-- Reviewable:end -->
