### PR TITLE
redirect output to stdout.log

### DIFF
--- a/core/algorithm-debug/dockerfile/Dockerfile
+++ b/core/algorithm-debug/dockerfile/Dockerfile
@@ -8,7 +8,8 @@ ARG BASE_PRIVATE_REGISTRY=""
 FROM ${BASE_PRIVATE_REGISTRY}hkube/base-node:v2.0.1-buster
 LABEL maintainer="yehiyam@gmail.com"
 RUN mkdir /hkube
+RUN mkdir -p /hkube-logs
 COPY . /hkube/algorithm-debug
 COPY --from=install /hkube/algorithm-debug/node_modules /hkube/algorithm-debug/node_modules
 WORKDIR /hkube/algorithm-debug
-CMD ["node", "app.js"]
+CMD ["/bin/sh", "-c", "mkfifo /tmp/pipe; (tee -a /hkube-logs/stdout.log < /tmp/pipe & ) ; exec npm start > /tmp/pipe 2>&1"]


### PR DESCRIPTION
![image](https://github.com/kube-HPC/hkube/assets/34660076/813f57e2-1acb-4c56-bf2c-d05093386867)

issue kube-HPC/hkube#1751
redirected the output, in a simillar fashion as the nodejs wrapper does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/1752)
<!-- Reviewable:end -->
