### PR TITLE
Autoscaler stateless count changes

### DIFF
--- a/core/api-server/api/graphql/schemas/job-schema.js
+++ b/core/api-server/api/graphql/schemas/job-schema.js
@@ -66,7 +66,8 @@ type  Batch {
     boards: [String ]
     output: Output
     input: [NodeInput ] 
-  
+    minStatelessCount: Int
+    maxStatelessCount: Int
     error:String
     warnings:[String]
     retries:Int

--- a/core/api-server/lib/validation/pipelines.js
+++ b/core/api-server/lib/validation/pipelines.js
@@ -1,4 +1,4 @@
-const { nodeKind, stateType} = require('@hkube/consts');
+const { nodeKind, stateType } = require('@hkube/consts');
 const { InvalidDataError } = require('../errors');
 
 class ApiValidator {

--- a/core/api-server/tests/pipelines-store.js
+++ b/core/api-server/tests/pipelines-store.js
@@ -545,6 +545,7 @@ describe('Store/Pipelines', () => {
                         {
                             nodeName: 'A',
                             kind: 'gateway',
+                            stateType: 'stateless'
                         },
                         {
                             nodeName: 'B',
@@ -566,6 +567,146 @@ describe('Store/Pipelines', () => {
             expect(response.body).to.have.property('error');
             expect(response.body.error.code).to.equal(StatusCodes.BAD_REQUEST);
             expect(response.body.error.message).to.equal('Gateway node A stateType must be "stateful". Got stateless');
+        });
+        it('should throw validation error for minStatelessCount', async () => {
+            const options = {
+                uri: restPath,
+                method: 'POST',
+                body: {
+                    kind: 'stream',
+                    name: 'string1',
+                    nodes: [
+                        {
+                            nodeName: 'A',
+                            kind: 'gateway',
+                            stateType:'stateful',
+                            minStatelessCount: 1
+                        },
+                        {
+                            nodeName: 'B',
+                            kind: 'algorithm',
+                            algorithmName: 'green-alg',
+                            input: []
+                        }
+                    ],
+                    streaming: {
+                        flows: {
+                            analyze: 'A >> B'
+                        }
+                    }
+                }
+            };
+            const response1 = await request(options);
+            const response = await request(options);
+            expect(response.body).to.have.property('error');
+            expect(response.body.error.code).to.equal(StatusCodes.BAD_REQUEST);
+            expect(response.body.error.message).to.equal('Nodes which are not stateType=stateless cant have minStatelessCount or maxStatelessCount'
+            );
+        });
+        it('should throw validation error for maxStatelessCount', async () => {
+            const options = {
+                uri: restPath,
+                method: 'POST',
+                body: {
+                    kind: 'stream',
+                    name: 'string2',
+                    nodes: [
+                        {
+                            nodeName: 'A',
+                            kind: 'gateway',
+                            stateType:'stateful',
+                        },
+                        {
+                            nodeName: 'B',
+                            kind: 'algorithm',
+                            algorithmName: 'green-alg',
+                            maxStatelessCount: 1,
+                            input: []
+                        }
+                    ],
+                    streaming: {
+                        flows: {
+                            analyze: 'A >> B'
+                        }
+                    }
+                }
+            };
+            const response1 = await request(options);
+            const response = await request(options);
+            expect(response.body).to.have.property('error');
+            expect(response.body.error.code).to.equal(StatusCodes.BAD_REQUEST);
+            expect(response.body.error.message).to.equal('Nodes which are not stateType=stateless cant have minStatelessCount or maxStatelessCount'
+            );
+        });
+        it('should throw validation error when maxStatelessCount larger than min', async () => {
+            const options = {
+                uri: restPath,
+                method: 'POST',
+                body: {
+                    kind: 'stream',
+                    name: 'maxstateless',
+                    nodes: [
+                        {
+                            nodeName: 'A',
+                            kind: 'gateway',
+                            stateType:'stateful',
+                        },
+                        {
+                            nodeName: 'B',
+                            kind: 'algorithm',
+                            algorithmName: 'green-alg',
+                            stateType:'stateless',
+                            maxStatelessCount: 3,
+                            minStatelessCount : 5,
+                            input: []
+                        }
+                    ],
+                    streaming: {
+                        flows: {
+                            analyze: 'A >> B'
+                        }
+                    }
+                }
+            };
+            // const response1 = await request(options);
+            const response = await request(options);
+            expect(response.body).to.have.property('error');
+            expect(response.response.statusCode).to.equal(StatusCodes.BAD_REQUEST);
+            expect(response.body.error.message).to.equal('maxStatelessCount must be greater or equal to minStatelessCount');
+        });
+        it('should successfully store pipeline with min and max stateless count', async () => {
+            const options = {
+                uri: restPath,
+                method: 'POST',
+                body: {
+                    kind: 'stream',
+                    name: 'maxstateless',
+                    nodes: [
+                        {
+                            nodeName: 'A',
+                            kind: 'gateway',
+                            stateType:'stateful',
+                        },
+                        {
+                            nodeName: 'B',
+                            kind: 'algorithm',
+                            algorithmName: 'green-alg',
+                            stateType:'stateless',
+                            maxStatelessCount: 7,
+                            minStatelessCount : 5,
+                            input: []
+                        }
+                    ],
+                    streaming: {
+                        flows: {
+                            analyze: 'A >> B'
+                        }
+                    }
+                }
+            };
+            const response = await request(options);
+            expect(response.body).to.have.property('streaming');
+            expect(response.response.statusCode).to.equal(StatusCodes.CREATED);
         });
     });
 });

--- a/core/worker/config/main/config.base.js
+++ b/core/worker/config/main/config.base.js
@@ -44,7 +44,7 @@ config.streaming = {
             minQueueSizeBeforeScaleDown: formatters.parseInt(process.env.AUTO_SCALER_MIN_QUEUE_SIZE_BEFORE_SCALE_DOWN, 0),
             minTimeQueueEmptyBeforeScaleDown: formatters.parseInt(process.env.AUTO_SCALER_MIN_TIME_QUEUE_EMPTY, 60000),
         },
-        scaleInvervention: {
+        scaleIntervention: {
             throttleMs : process.env.SCALE_INTERVENTION_LOG_THROTTLE_TIME || 200
         }
     },

--- a/core/worker/config/main/config.base.js
+++ b/core/worker/config/main/config.base.js
@@ -43,6 +43,9 @@ config.streaming = {
             minTimeIdleBeforeReplicaDown: formatters.parseInt(process.env.AUTO_SCALER_MIN_TIME_WAIT_REPLICA_DOWN, 60000),
             minQueueSizeBeforeScaleDown: formatters.parseInt(process.env.AUTO_SCALER_MIN_QUEUE_SIZE_BEFORE_SCALE_DOWN, 0),
             minTimeQueueEmptyBeforeScaleDown: formatters.parseInt(process.env.AUTO_SCALER_MIN_TIME_QUEUE_EMPTY, 60000),
+        },
+        scaleInvervention: {
+            throttleMs : process.env.SCALE_INTERVENTION_LOG_THROTTLE_TIME || 200
         }
     },
     election: {

--- a/core/worker/lib/streaming/core/scaler.js
+++ b/core/worker/lib/streaming/core/scaler.js
@@ -20,15 +20,13 @@ const SCALE_STATUS = {
  * the logic of scale up/down feasibility
  */
 class Scaler {
-    constructor(config, statelessSizeLimits, methods) {
+    constructor(config, methods) {
         log = Logger.GetLogFromContainer();
         this._maxScaleUpReplicasPerNode = config.scaleUp.maxScaleUpReplicasPerNode;
         this._maxScaleUpReplicasPerTick = config.scaleUp.maxScaleUpReplicasPerTick;
         this._minTimeWaitBeforeRetryScale = config.minTimeWaitBeforeRetryScale;
         this._minTimeBetweenScales = config.minTimeBetweenScales;
         this._scaleInterval = config.scaleInterval;
-        this._minStateless = statelessSizeLimits.minStateless;
-        this._maxStateless = statelessSizeLimits.maxStateless;
         this._getQueue = methods.getQueue;
         this._getUnScheduledAlgorithm = methods.getUnScheduledAlgorithm;
         this._getCurrentSize = methods.getCurrentSize;
@@ -120,15 +118,6 @@ class Scaler {
         if (currentSize < this._required
             && (!this._lastScaleDownTime || Date.now() - this._lastScaleDownTime > this._minTimeBetweenScales)) {
             if (this._desired <= currentSize) {
-                if (this._maxStateless === currentSize) {
-                    this._scalingInterventionLog(); // Can't scale anymore
-                    return shouldScaleUp;
-                }
-                // eslint-disable-next-line no-else-return
-                else if (this.required > this._maxStateless) { // Maintain max stateless at most.
-                    this._required = this._maxStateless;
-                    this._scalingInterventionLog(); // Scaling  cieling reached.
-                }
                 shouldScaleUp = true;
                 this._notFulfilledTimeUp = null;
             }
@@ -170,11 +159,6 @@ class Scaler {
             }
         }
         return shouldScaleDown;
-    }
-
-    _scalingInterventionLog(action, required, allowed) {
-        // TODO : Timestamp to avoid spamming logs
-        log.info(`scaling ${action} intervention, from ${required} to ${allowed} `, { component });
     }
 }
 

--- a/core/worker/lib/streaming/core/scaler.js
+++ b/core/worker/lib/streaming/core/scaler.js
@@ -20,7 +20,7 @@ const SCALE_STATUS = {
  * the logic of scale up/down feasibility
  */
 class Scaler {
-    constructor(config, methods) {
+    constructor(config, minStatelessCount, methods) {
         log = Logger.GetLogFromContainer();
         this._maxScaleUpReplicasPerNode = config.scaleUp.maxScaleUpReplicasPerNode;
         this._maxScaleUpReplicasPerTick = config.scaleUp.maxScaleUpReplicasPerTick;
@@ -33,7 +33,7 @@ class Scaler {
         this._scaleUp = methods.scaleUp;
         this._scaleDown = methods.scaleDown;
         this._required = 0;
-        this._desired = 0;
+        this._desired = minStatelessCount || 0;
         this._lastScaleUpTime = null;
         this._lastScaleDownTime = null;
         this._scale = false;

--- a/core/worker/lib/streaming/core/scaler.js
+++ b/core/worker/lib/streaming/core/scaler.js
@@ -20,13 +20,15 @@ const SCALE_STATUS = {
  * the logic of scale up/down feasibility
  */
 class Scaler {
-    constructor(config, methods) {
+    constructor(config, statelessSizeLimits, methods) {
         log = Logger.GetLogFromContainer();
         this._maxScaleUpReplicasPerNode = config.scaleUp.maxScaleUpReplicasPerNode;
         this._maxScaleUpReplicasPerTick = config.scaleUp.maxScaleUpReplicasPerTick;
         this._minTimeWaitBeforeRetryScale = config.minTimeWaitBeforeRetryScale;
         this._minTimeBetweenScales = config.minTimeBetweenScales;
         this._scaleInterval = config.scaleInterval;
+        this._minStateless = statelessSizeLimits.minStateless;
+        this._maxStateless = statelessSizeLimits.maxStateless;
         this._getQueue = methods.getQueue;
         this._getUnScheduledAlgorithm = methods.getUnScheduledAlgorithm;
         this._getCurrentSize = methods.getCurrentSize;
@@ -118,6 +120,15 @@ class Scaler {
         if (currentSize < this._required
             && (!this._lastScaleDownTime || Date.now() - this._lastScaleDownTime > this._minTimeBetweenScales)) {
             if (this._desired <= currentSize) {
+                if (this._maxStateless === currentSize) {
+                    this._scalingInterventionLog(); // Can't scale anymore
+                    return shouldScaleUp;
+                }
+                // eslint-disable-next-line no-else-return
+                else if (this.required > this._maxStateless) { // Maintain max stateless at most.
+                    this._required = this._maxStateless;
+                    this._scalingInterventionLog(); // Scaling  cieling reached.
+                }
                 shouldScaleUp = true;
                 this._notFulfilledTimeUp = null;
             }
@@ -159,6 +170,11 @@ class Scaler {
             }
         }
         return shouldScaleDown;
+    }
+
+    _scalingInterventionLog(action, required, allowed) {
+        // TODO : Timestamp to avoid spamming logs
+        log.info(`scaling ${action} intervention, from ${required} to ${allowed} `, { component });
     }
 }
 

--- a/core/worker/lib/streaming/services/auto-scaler.js
+++ b/core/worker/lib/streaming/services/auto-scaler.js
@@ -66,7 +66,7 @@ class AutoScaler {
             if (this._options.node.kind === nodeKind.Debug) {
                 conf = { ...this._config, scaleUp: { ...this._config.scaleUp, maxScaleUpReplicasPerNode: 1 } };
             }
-            this._scaler = new Scaler(conf, {
+            this._scaler = new Scaler(conf, this._statelessCountLimits.minStateless, {
                 getCurrentSize: () => {
                     return discovery.countInstances(this._nodeName);
                 },

--- a/core/worker/lib/streaming/services/auto-scaler.js
+++ b/core/worker/lib/streaming/services/auto-scaler.js
@@ -217,7 +217,6 @@ class AutoScaler {
     }
 
     _scalingInterventionLog(action, required, allowed) {
-        // TODO : Timestamp to avoid spamming logs
         const currentTime = Date.now();
         // Log-spam prevention
         if (this._interventionLogCallTrack.timeStamp) {
@@ -225,7 +224,7 @@ class AutoScaler {
                 && this._interventionLogCallTrack.required === required
                 && this._interventionLogCallTrack.allowed.type === allowed.type
                 && this._interventionLogCallTrack.allowed.size === allowed.size
-                && currentTime - this._interventionLogCallTrack.timeStamp < this._config.scaleInvervention.throttleMs) {
+                && currentTime - this._interventionLogCallTrack.timeStamp < this._config.scaleIntervention.throttleMs) {
                 return;
             }
         }
@@ -374,9 +373,6 @@ class AutoScaler {
         const discoveryWorkers = discovery.getInstances(this._nodeName);
         // we will prefer not to scale-down masters, unless we scaling down to zero
         const instances = scaleTo === 0 ? discoveryWorkers : discoveryWorkers.filter(d => !d.isMaster);
-        // if (this._minStatelessCount > 0 && (currentSize - replicas < this._minStatelessCount)) {
-        //     const replicaDeductedMin = currentSize - this.minStatelessCount;
-        // }
         const workers = instances.slice(0, replicas);
         return Promise.all(workers.map(w => stateAdapter.stopWorker({ workerId: w.workerId })));
     }

--- a/core/worker/test/streaming.js
+++ b/core/worker/test/streaming.js
@@ -732,7 +732,8 @@ describe('Streaming', () => {
             slave1.report(list1);
             slave2.report(list2);
             await delay(500);
-            const masters = getMasters();
+            let masters = getMasters();
+            masters = masters.filter(m => m.nodeName === nodeName);
             const slaves = masters[0].slaves();
             expect(slaves.sort()).to.deep.equal([slave1.source, slave2.source])
         });

--- a/core/worker/test/streaming.js
+++ b/core/worker/test/streaming.js
@@ -637,7 +637,7 @@ describe('Streaming', () => {
             const scale = autoScale(list[0].nodeName);
             expect(scale.required).to.eql(0);
         });
-        it.only('should not over the maxSizeWindow', async () => {
+        it('should not over the maxSizeWindow', async () => {
             const nodeName = 'D';
             const data = [{
                 nodeName,


### PR DESCRIPTION
- Handle min and max auto-scaling limits, including logs throttling ( process.env.SCALE_INTERVENTION_LOG_THROTTLE_TIME )

- Updated graph schema
- Added pipeline store validation for stateless count.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/1783)
<!-- Reviewable:end -->
