### PR TITLE
Gc taskStatus cleaner

### DIFF
--- a/core/gc-service/config/main/config.base.js
+++ b/core/gc-service/config/main/config.base.js
@@ -110,7 +110,7 @@ config.cleanerSettings = {
         cron: process.env.TASKSTATUS_CRON || '* * * * *',
         enabled: formatter.parseBool(process.env.TASKSTATUS_ENABLED, true),
         settings: {
-            maxInterval:12000
+            pdIntervalBreach:12000
         }
     }
 };

--- a/core/gc-service/config/main/config.base.js
+++ b/core/gc-service/config/main/config.base.js
@@ -105,6 +105,13 @@ config.cleanerSettings = {
                 builds: formatter.parseFloat(process.env.BUILDS_MAX_AGE, 1 * 60 * 24),
             }
         }
+    },
+    taskStatus: {
+        cron: process.env.TASKSTATUS_CRON || '*/2 * * * *',
+        enabled: formatter.parseBool(process.env.TASKSTATUS_ENABLED, true),
+        settings: {
+            
+        }
     }
 };
 

--- a/core/gc-service/config/main/config.base.js
+++ b/core/gc-service/config/main/config.base.js
@@ -110,7 +110,7 @@ config.cleanerSettings = {
         cron: process.env.TASKSTATUS_CRON || '* * * * *',
         enabled: formatter.parseBool(process.env.TASKSTATUS_ENABLED, true),
         settings: {
-            
+            maxInterval:12000
         }
     }
 };

--- a/core/gc-service/config/main/config.base.js
+++ b/core/gc-service/config/main/config.base.js
@@ -107,7 +107,7 @@ config.cleanerSettings = {
         }
     },
     taskStatus: {
-        cron: process.env.TASKSTATUS_CRON || '*/2 * * * *',
+        cron: process.env.TASKSTATUS_CRON || '* * * * *',
         enabled: formatter.parseBool(process.env.TASKSTATUS_ENABLED, true),
         settings: {
             

--- a/core/gc-service/config/main/config.test.js
+++ b/core/gc-service/config/main/config.test.js
@@ -9,6 +9,15 @@ config.fs = {
 config.healthchecks = {
     enabled: false
 };
+config.cleanerSettings = {
+    taskStatus:{
+        cron: process.env.TASKSTATUS_CRON || '* * * * *',
+        // enabled: formatter.parseBool(process.env.TASKSTATUS_ENABLED, true),
+        settings:{
+        maxInterval: 3600000  
+        }
+    }
+}
 
 module.exports = config;
 

--- a/core/gc-service/config/main/config.test.js
+++ b/core/gc-service/config/main/config.test.js
@@ -12,9 +12,8 @@ config.healthchecks = {
 config.cleanerSettings = {
     taskStatus:{
         cron: process.env.TASKSTATUS_CRON || '* * * * *',
-        // enabled: formatter.parseBool(process.env.TASKSTATUS_ENABLED, true),
         settings:{
-        maxInterval: 3600000  
+            pdIntervalBreach: 3600000  
         }
     }
 }

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -52,6 +52,8 @@ class TaskStatusCleaner extends BaseCleaner {
                     if (obj.status === 'warning' && node.status !== 'warning') {
                     // eslint-disable-next-line no-param-reassign
                         node.status = 'warning';
+                        // eslint-disable-next-line no-param-reassign
+                        node.warning = obj.warning;
                         warningExist = true;
                     }
                 }

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -10,12 +10,6 @@ class TaskStatusCleaner extends BaseCleaner {
         this.INTERVAL = config.config.settings.maxInterval;
     }
 
-    // async clean() {
-    //     const updatedJobIds = [];
-    //     updatedJobIds.push(...(await this.cleanCycle()));
-    //     return updatedJobIds;
-    // }
-
     async clean() {
         const graphs = await storeManager.getRunningJobsGraphs();
         const filteredGraphsList = graphs.filter(element => Date.now() - element.pdIntervalTimestamp >= this.INTERVAL);

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -5,36 +5,49 @@ const etcdStore = require('../../helpers/etcd');
 const tryParseJson = require('../../utils/tryParseJson');
 
 class TaskStatusCleaner extends BaseCleaner {
+    // eslint-disable-next-line no-useless-constructor
+    constructor(config) {
+        super(config);
+        this.INTERVAL = config.config.settings.maxInterval;
+    }
+
     async clean() {
+        const updatedJobIds = [];
+        let tmpList = [];
         const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
         log.debug('starting first run of taskStatus Cleaner in the current cycle');
-        this.oneCheckCycle();
+        tmpList = this.oneCheckCycle();
         await sleep(30000);
         log.debug('starting second run of taskStatus Cleaner in the current cycle');
-        await this.oneCheckCycle();
+        updatedJobIds.push(...(await this.oneCheckCycle()));
+        updatedJobIds.push(...tmpList);
+        return updatedJobIds;
     }
 
     async oneCheckCycle() {
         const graphs = await storeManager.getRunningJobsGraphs();
-        const graphsList = [];
-        graphs.forEach(graph => {
-            graphsList.push(graph.graph);
-            graphsList[graphsList.length - 1].pdIntervalTimestamp = graph.pdIntervalTimestamp;
-        });
-        const filteredGraphsList = graphsList.filter(graph => Date.now() - graph.pdIntervalTimestamp >= 8000);
+        const filteredGraphsList = graphs.filter(graph => Date.now() - graph.pdIntervalTimestamp >= this.INTERVAL);
         if (filteredGraphsList.length === 0) {
-            return;
+            return [];
         }
-        graphsList.forEach(graph => {
+        graphs.forEach(element => {
             // eslint-disable-next-line no-param-reassign
-            delete graph.pdIntervalTimestamp;
+            delete element.pdIntervalTimestamp;
         });
-        await this.handleWarnings(graphsList);
+        const graphsList = [];
+        graphs.array.forEach(element => {
+            graphsList.push(element.graph);
+        });
+
+        const updatedJobIds = await this.handleWarnings(graphsList);
+
+        return updatedJobIds;
     }
 
     // new
     async handleWarnings(graphs = []) {
         const warningGraphs = [...graphs];
+        const updatedJobIds = [];
         for (let i = 0; i < warningGraphs.length; i += 1) {
             const { jobId } = warningGraphs[i];
 
@@ -44,19 +57,23 @@ class TaskStatusCleaner extends BaseCleaner {
                     // eslint-disable-next-line no-param-reassign
                     node.batch = await this.handleBatch(node.batch, jobId);
                 }
-                const { taskId } = node;
-                const path = `/jobs/tasks/${jobId}/${taskId}`;
-                const data = await etcdStore.getKeys(path);
-                const obj = tryParseJson(data[0]);
-                if (obj.status === 'warning') {
+                else {
+                    const { taskId } = node;
+                    const path = `/jobs/tasks/${jobId}/${taskId}`;
+                    const data = await etcdStore.getKeys(path);
+                    const obj = tryParseJson(data[0]);
+                    if (obj.status === 'warning') {
                     // eslint-disable-next-line no-param-reassign
-                    node.status = 'warning';
+                        node.status = 'warning';
+                    }
                 }
             }));
 
             // eslint-disable-next-line no-await-in-loop
             await storeManager._db.Jobs.updateGraph({ jobId, graph: warningGraphs[i] });
+            updatedJobIds.push(jobId);
         }
+        return updatedJobIds;
     }
 
     async handleBatch(batch = [], jobId) {

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -1,3 +1,4 @@
+const log = require('@hkube/logger').GetLogFromContainer();
 const BaseCleaner = require('../../core/base-cleaner');
 const storeManager = require('../../helpers/store-manager');
 const etcdStore = require('../../helpers/etcd');
@@ -5,10 +6,15 @@ const tryParseJson = require('../../utils/tryParseJson');
 
 class TaskStatusCleaner extends BaseCleaner {
     async clean() {
-        // const { batch, normal } = await this.getGraphs();
-        // const fixednormal = await this.handleNormal(normal);
+        const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+        log.debug('starting first run of taskStatus Cleaner in the current cycle');
+        this.oneCheckCycle();
+        await sleep(30000);
+        log.debug('starting second run of taskStatus Cleaner in the current cycle');
+        await this.oneCheckCycle();
+    }
 
-        // checking a new idea
+    async oneCheckCycle() {
         const graphs = await storeManager.getRunningJobsGraphs();
         const filteredGraphsList = graphs.filter(graph => Date.now() - graph.pdIntervalTimestamp >= 8000);
         if (filteredGraphsList.length === 0) {

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -16,10 +16,8 @@ class TaskStatusCleaner extends BaseCleaner {
         if (filteredGraphsList.length === 0) {
             return [];
         }
-        const graphsList = [];
-
-        filteredGraphsList.map(element => {
-            return graphsList.push(element.graph);
+        const graphsList = filteredGraphsList.map(element => {
+            return element.graph;
         });
 
         const updatedJobIds = await this.synchDBWithEtcdWarnings(graphsList);
@@ -29,14 +27,13 @@ class TaskStatusCleaner extends BaseCleaner {
 
     // new
     async synchDBWithEtcdWarnings(graphs = []) {
-        const warningGraphs = [...graphs];
         const updatedJobIds = [];
-        for (let i = 0; i < warningGraphs.length; i += 1) {
-            const { jobId } = warningGraphs[i];
+        for (let i = 0; i < graphs.length; i += 1) {
+            const { jobId } = graphs[i];
             let warningExist = false;
 
             // eslint-disable-next-line no-await-in-loop
-            await Promise.all(warningGraphs[i].nodes.map(async (node) => {
+            await Promise.all(graphs[i].nodes.map(async (node) => {
                 if ('batch' in node) {
                     let warningExistTmp = false;
                     // eslint-disable-next-line no-param-reassign
@@ -62,7 +59,7 @@ class TaskStatusCleaner extends BaseCleaner {
 
             if (warningExist) {
                 // eslint-disable-next-line no-await-in-loop
-                await storeManager._db.jobs.updateGraph({ jobId, graph: warningGraphs[i] });
+                await storeManager._db.jobs.updateGraph({ jobId, graph: graphs[i] });
                 updatedJobIds.push(jobId);
             }
         }

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -1,33 +1,122 @@
 const BaseCleaner = require('../../core/base-cleaner');
 const storeManager = require('../../helpers/store-manager');
+const etcdStore = require('../../helpers/etcd');
+const tryParseJson = require('../../utils/tryParseJson');
 
 class TaskStatusCleaner extends BaseCleaner {
     async clean() {
-        const { batch, normal } = await this.getGraphs();
-        batch + normal; // a place holder so i can keep the code without eslint throwing an error
+        // const { batch, normal } = await this.getGraphs();
+        // const fixednormal = await this.handleNormal(normal);
+
+        // checking a new idea
+
+        const graphs = storeManager.getRunningJobsGraphs();
+
+        // subject to change because on moday i will make it so that the methods return a list of objects that
+        // have jobId taskId and warning message and these objects will be of the tasks that have new warnings
+        // eslint-disable-next-line no-unused-vars
+        const warningGraphs = this.checkWarnings(graphs);
     }
 
-    async getGraphs() {
-        const graphs = await storeManager.getRunningJobsGraphs();
-        const batch = [];
-        const normal = [];
-        let flag = true;
+    // //old
+    // async getGraphs() {
+    //     const graphs = await storeManager.getRunningJobsGraphs();
+    //     const batch = [];
+    //     const normal = [];
+    //     let flag = true;
+    //     for (let i = 0; i < graphs.length; i += 1) {
+    //         for (let j = 0; j < graphs[i].nodes.length; i += 1) {
+    //             if ('batch' in graphs[i].nodes[j]) {
+    //                 batch.push(graphs[i]);
+    //                 flag = false;
+    //                 break;
+    //             }
+    //         }
+    //         if (flag) {
+    //             normal.push(graphs[i]);
+    //         }
+
+    //         flag = true;
+    //     }
+    //     return { batch, normal };
+    // }
+
+    // new
+    async checkWarnings(graphs = []) {
+        const warningGraphs = [];
         for (let i = 0; i < graphs.length; i += 1) {
-            for (let j = 0; j < graphs[i].nodes.length; i += 1) {
-                if ('batch' in graphs[i].nodes[j]) {
-                    batch.push(graphs[i]);
-                    flag = false;
-                    break;
-                }
-            }
-            if (flag) {
-                normal.push(graphs[i]);
-            }
+            const { jobId } = graphs[i];
+            let warningExist = false;
 
-            flag = true;
+            // eslint-disable-next-line no-await-in-loop
+            await Promise.all(graphs[i].nodes.map(async (node) => {
+                if ('batch' in node) {
+                    // eslint-disable-next-line no-param-reassign
+                    ({ batch: node.batch, warningExist } = this.handleBatch(node.batch, jobId));
+                }
+                const { taskId } = node;
+                const path = `/jobs/tasks/${jobId}/${taskId}`;
+                const data = await etcdStore.getKeys(path);
+                const obj = tryParseJson(data[0]);
+                if (obj.status === 'warning') {
+                    // eslint-disable-next-line no-param-reassign
+                    node.status = 'warning';
+                    warningExist = true;
+                }
+            }));
+
+            if (warningExist === true) {
+                warningGraphs.push(graphs[i]);
+            }
         }
-        return { batch, normal };
+
+        return warningGraphs;
     }
+
+    // new
+    async handleBatch(batch = [], jobId) {
+        let warningExist = false;
+        await Promise.all(batch.map(async (task) => {
+            const { taskId } = task;
+            const path = `/jobs/tasks/${jobId}/${taskId}`;
+            const data = await etcdStore.getKeys(path);
+            const obj = tryParseJson(data[0]);
+            if (obj.status === 'warning') {
+                warningExist = true;
+                // eslint-disable-next-line no-param-reassign
+                task.status = 'warning';
+            }
+        }));
+        return { batch, warningExist };
+    }
+
+    // // old
+    // async handleNormal(graphs = []) {
+    //     const warningGraphs = [];
+    //     for (let i = 0; i < graphs.length; i += 1) {
+    //         const { jobId } = graphs[i];
+    //         let warningExist = false;
+
+    //         // eslint-disable-next-line no-await-in-loop
+    //         await Promise.all(graphs[i].nodes.map(async (node) => {
+    //             const { taskId } = node;
+    //             const path = `/jobs/tasks/${jobId}/${taskId}`;
+    //             const data = await etcdStore.getKeys(path);
+    //             const obj = tryParseJson(data[0]);
+    //             if (obj.status === 'warning') {
+    //                 // eslint-disable-next-line no-param-reassign
+    //                 node.status = 'warning';
+    //                 warningExist = true;
+    //             }
+    //         }));
+
+    //         if (warningExist === true) {
+    //             warningGraphs.push(graphs[i]);
+    //         }
+    //     }
+
+    //     return warningGraphs;
+    // }
 }
 
 module.exports = TaskStatusCleaner;

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -16,12 +16,20 @@ class TaskStatusCleaner extends BaseCleaner {
 
     async oneCheckCycle() {
         const graphs = await storeManager.getRunningJobsGraphs();
-        const filteredGraphsList = graphs.filter(graph => Date.now() - graph.pdIntervalTimestamp >= 8000);
+        const graphsList = [];
+        graphs.forEach(graph => {
+            graphsList.push(graph.graph);
+            graphsList[graphsList.length - 1].pdIntervalTimestamp = graph.pdIntervalTimestamp;
+        });
+        const filteredGraphsList = graphsList.filter(graph => Date.now() - graph.pdIntervalTimestamp >= 8000);
         if (filteredGraphsList.length === 0) {
             return;
         }
-
-        await this.handleWarnings(graphs);
+        graphsList.forEach(graph => {
+            // eslint-disable-next-line no-param-reassign
+            delete graph.pdIntervalTimestamp;
+        });
+        await this.handleWarnings(graphsList);
     }
 
     // new

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -1,0 +1,33 @@
+const BaseCleaner = require('../../core/base-cleaner');
+const storeManager = require('../../helpers/store-manager');
+
+class TaskStatusCleaner extends BaseCleaner {
+    async clean() {
+        const { batch, normal } = await this.getGraphs();
+        batch + normal; // a place holder so i can keep the code without eslint throwing an error
+    }
+
+    async getGraphs() {
+        const graphs = await storeManager.getRunningJobsGraphs();
+        const batch = [];
+        const normal = [];
+        let flag = true;
+        for (let i = 0; i < graphs.length; i += 1) {
+            for (let j = 0; j < graphs[i].nodes.length; i += 1) {
+                if ('batch' in graphs[i].nodes[j]) {
+                    batch.push(graphs[i]);
+                    flag = false;
+                    break;
+                }
+            }
+            if (flag) {
+                normal.push(graphs[i]);
+            }
+
+            flag = true;
+        }
+        return { batch, normal };
+    }
+}
+
+module.exports = TaskStatusCleaner;

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -48,7 +48,7 @@ class TaskStatusCleaner extends BaseCleaner {
                     const { taskId } = node;
                     const path = `/jobs/tasks/${jobId}/${taskId}`;
                     const data = await etcdStore.getKeys(path);
-                    const obj = tryParseJson(data[0]);
+                    const obj = tryParseJson(data.path);
                     if (obj.status === 'warning' && node.status !== 'warning') {
                     // eslint-disable-next-line no-param-reassign
                         node.status = 'warning';

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -48,7 +48,7 @@ class TaskStatusCleaner extends BaseCleaner {
                     const { taskId } = node;
                     const path = `/jobs/tasks/${jobId}/${taskId}`;
                     const data = await etcdStore.getKeys(path);
-                    const obj = tryParseJson(data.path);
+                    const obj = tryParseJson(Object.values(data)[0]);
                     if (obj.status === 'warning' && node.status !== 'warning') {
                     // eslint-disable-next-line no-param-reassign
                         node.status = 'warning';

--- a/core/gc-service/lib/cleaners/taskStatus/index.js
+++ b/core/gc-service/lib/cleaners/taskStatus/index.js
@@ -1,4 +1,3 @@
-const log = require('@hkube/logger').GetLogFromContainer();
 const BaseCleaner = require('../../core/base-cleaner');
 const storeManager = require('../../helpers/store-manager');
 const etcdStore = require('../../helpers/etcd');
@@ -11,23 +10,13 @@ class TaskStatusCleaner extends BaseCleaner {
         this.INTERVAL = config.config.settings.maxInterval;
     }
 
-    async clean(sleepTime = 30000) {
-        const updatedJobIds = [];
-        let tmpList = [];
-        const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-        log.debug('starting first run of taskStatus Cleaner in the current cycle');
-        [tmpList] = await Promise.all([
-            this.oneCheckCycle(),
-            sleep(sleepTime)
-        ]);
+    // async clean() {
+    //     const updatedJobIds = [];
+    //     updatedJobIds.push(...(await this.cleanCycle()));
+    //     return updatedJobIds;
+    // }
 
-        log.debug('starting second run of taskStatus Cleaner in the current cycle');
-        updatedJobIds.push(...(await this.oneCheckCycle()));
-        updatedJobIds.push(...tmpList);
-        return updatedJobIds;
-    }
-
-    async oneCheckCycle() {
+    async clean() {
         const graphs = await storeManager.getRunningJobsGraphs();
         const filteredGraphsList = graphs.filter(element => Date.now() - element.pdIntervalTimestamp >= this.INTERVAL);
         if (filteredGraphsList.length === 0) {

--- a/core/gc-service/lib/helpers/store-manager.js
+++ b/core/gc-service/lib/helpers/store-manager.js
@@ -28,6 +28,7 @@ class StoreManager {
         return this._db.jobs.search({
             hasResult: false,
             fields: {
+                pdIntervalTimestamp: 'pdIntervalTimestamp',
                 graph: 'graph'
             },
         });

--- a/core/gc-service/lib/helpers/store-manager.js
+++ b/core/gc-service/lib/helpers/store-manager.js
@@ -24,6 +24,11 @@ class StoreManager {
         });
     }
 
+    async getRunningJobsGraphs() {
+        // jsdhkjdshdshhsdhsdohsd
+
+    }
+
     async getInvalidStatusJobs() {
         return this._db.jobs.fetchAll({
             query: {

--- a/core/gc-service/lib/helpers/store-manager.js
+++ b/core/gc-service/lib/helpers/store-manager.js
@@ -25,8 +25,12 @@ class StoreManager {
     }
 
     async getRunningJobsGraphs() {
-        // jsdhkjdshdshhsdhsdohsd
-
+        return this._db.jobs.search({
+            hasResult: false,
+            fields: {
+                graph: 'graph'
+            },
+        });
     }
 
     async getInvalidStatusJobs() {

--- a/core/gc-service/package-lock.json
+++ b/core/gc-service/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hkube/config": "^2.0.11",
         "@hkube/consts": "^1.0.39",
-        "@hkube/db": "^1.0.42",
+        "@hkube/db": "^2.0.14",
         "@hkube/etcd": "^5.1.6",
         "@hkube/healthchecks": "^1.0.2",
         "@hkube/kubernetes-client": "^1.0.35",
@@ -446,11 +446,11 @@
       "integrity": "sha512-vDFolDFWo+lBheKq6FFObVyxPAVX4KViHtOt8cl5Y/iKbv4lMxeGO6IjWPA3PvuUG/1iZ0Uf2fcFX1GWpwxspg=="
     },
     "node_modules/@hkube/db": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@hkube/db/-/db-1.0.42.tgz",
-      "integrity": "sha512-qDTVzWPFVDSd+GUvuryzXYZVGotghLD8AwGoLtJjWHEaAU3P2dEv5FN4vDdX1IE0LvIYSXMOYD9PLq8dKFvO+A==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@hkube/db/-/db-2.0.14.tgz",
+      "integrity": "sha512-t60HPQ6R0J8MP9M6bOx2WwZB0rODbsv36a3f2xBd99/Qx/FVRpLaBmqsC6rFDUBuJr3M42iGejk5xsxY3c7gTg==",
       "dependencies": {
-        "@hkube/consts": "^1.0.31",
+        "@hkube/consts": "^1.0.40",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "moment": "^2.29.1",
@@ -8514,11 +8514,11 @@
       "integrity": "sha512-vDFolDFWo+lBheKq6FFObVyxPAVX4KViHtOt8cl5Y/iKbv4lMxeGO6IjWPA3PvuUG/1iZ0Uf2fcFX1GWpwxspg=="
     },
     "@hkube/db": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@hkube/db/-/db-1.0.42.tgz",
-      "integrity": "sha512-qDTVzWPFVDSd+GUvuryzXYZVGotghLD8AwGoLtJjWHEaAU3P2dEv5FN4vDdX1IE0LvIYSXMOYD9PLq8dKFvO+A==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@hkube/db/-/db-2.0.14.tgz",
+      "integrity": "sha512-t60HPQ6R0J8MP9M6bOx2WwZB0rODbsv36a3f2xBd99/Qx/FVRpLaBmqsC6rFDUBuJr3M42iGejk5xsxY3c7gTg==",
       "requires": {
-        "@hkube/consts": "^1.0.31",
+        "@hkube/consts": "^1.0.40",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "moment": "^2.29.1",

--- a/core/gc-service/package.json
+++ b/core/gc-service/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@hkube/config": "^2.0.11",
     "@hkube/consts": "^1.0.39",
-    "@hkube/db": "^1.0.42",
+    "@hkube/db": "^2.0.14",
     "@hkube/etcd": "^5.1.6",
     "@hkube/healthchecks": "^1.0.2",
     "@hkube/kubernetes-client": "^1.0.35",

--- a/core/gc-service/tests/etcd/mocks/etcd-store.js
+++ b/core/gc-service/tests/etcd/mocks/etcd-store.js
@@ -11,6 +11,18 @@ class StateManager {
         if (this.deleteInvoked) {
             return []
         }
+        if (path.includes("/jobs/tasks")){
+            const jobTasksJson = require('../../taskStatus/mocks/etcdStore.json')
+            const returnList = [];
+                for (let i =0; i<jobTasksJson.length; i+=1){
+                    if(path.includes(jobTasksJson[i].taskId )){
+                        returnList.push(JSON.stringify(jobTasksJson[i]));
+                        return returnList;
+                    }
+                }
+            }
+        
+            
         switch (path) {
             case "/webhooks":
                 const webhooks = require('./webhooks.json');

--- a/core/gc-service/tests/etcd/mocks/etcd-store.js
+++ b/core/gc-service/tests/etcd/mocks/etcd-store.js
@@ -13,11 +13,10 @@ class StateManager {
         }
         if (path.includes("/jobs/tasks")){
             const jobTasksJson = require('../../taskStatus/mocks/etcdStore.json')
-            const returnList = [];
                 for (let i =0; i<jobTasksJson.length; i+=1){
                     if(path.includes(jobTasksJson[i].taskId )){
-                        returnList.push(JSON.stringify(jobTasksJson[i]));
-                        return returnList;
+                        return {path: JSON.stringify(jobTasksJson[i])};
+                        
                     }
                 }
             }

--- a/core/gc-service/tests/pipelines/mocks/executions.js
+++ b/core/gc-service/tests/pipelines/mocks/executions.js
@@ -2,310 +2,415 @@ const moment = require('moment');
 
 module.exports = [
     {
-        "name": "test1",
-        "nodes": [
-            {
-                "nodeName": "green",
-                "algorithmName": "green-alg",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "test1",
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug"
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": 1532506623299,
+
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug"
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": 1532506623299
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {
+            "jobId": "job-0",
+            "timestamp": Date.now(),
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "taskId": "so7bw5d9",
+                    "podName": "green-5a611-9rkc5",
+                    "status": "active"
+                }
+
+            ]
+
+        }
     },
     {
-        "name": "test2",
-        "nodes": [
-            {
-                "nodeName": "green",
-                "algorithmName": "green-alg",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "test2",
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug"
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": 1532506623299,
+
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug"
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": 1532506623299
+        "pdIntervalTimestamp": moment().subtract(2, 'hours').toDate().getTime(),
+        "graph":
+        {
+            "jobId": "job-1",
+            "timestamp": Date.now(),
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "taskId": "6ahx4qad",
+                    "podName": "green-ygzyl-hlgtk",
+                    "status": "active"
+                }
+
+            ]
+
+        }
     },
     {
-        "name": "test3",
-        "nodes": [
-            {
-                "nodeName": "green",
-                "algorithmName": "green-alg",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "test3",
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug",
+                "ttl": 3800
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": Date.now(),
+
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug",
-            "ttl": 3800
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": Date.now()
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {
+            "jobId": "job-2",
+            "timestamp": Date.now(),
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "taskId": "q8sismx6",
+                    "podName": "green-rn7ph-24q9k",
+                    "status": "active"
+                }
+
+            ]
+
+        }
     },
     {
-        "name": "test4",
-        "nodes": [
-            {
-                "nodeName": "green",
-                "algorithmName": "green-alg",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "test4",
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug",
+                "ttl": 3800
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": Date.now(),
+
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug",
-            "ttl": 3800
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": Date.now()
+        "pdIntervalTimestamp": moment().subtract(2, 'hours').toDate().getTime(),
+        "graph": {
+            "jobId": "job-3",
+            "timestamp": Date.now(),
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "taskId": "337w0qdo",
+                    "podName": "green-nfbz8-ntvnc",
+                    "status": "active"
+                }
+
+            ]
+
+        }
     },
     {
-        "name": "expired pipeline1",
-        "nodes": [
-            {
-                "nodeName": "green",
-                "algorithmName": "green-alg",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "expired pipeline1",
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug",
+                "ttl": 20
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": moment().subtract(60, 'seconds').toDate().getTime()
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug",
-            "ttl": 20
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": moment().subtract(60, 'seconds').toDate().getTime()
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {}
     },
     {
-        "name": "expired pipeline2",
-        "nodes": [
-            {
-                "nodeName": "green",
-                "algorithmName": "green-alg",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "expired pipeline2",
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug",
+                "ttl": 30
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": moment().subtract(60, 'seconds').toDate().getTime()
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug",
-            "ttl": 30
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": moment().subtract(60, 'seconds').toDate().getTime()
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {}
     },
     {
-        "name": "active expired",
-        "nodes": [
-            {
-                "nodeName": "green",
-                "algorithmName": "green-alg",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "active expired",
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug",
+                "ttl": 90,
+                "activeTtl": 30
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": moment().subtract(60, 'seconds').toDate().getTime(),
+            "activeTime": moment().subtract(40, 'seconds').toDate().getTime()
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug",
-            "ttl": 90,
-            "activeTtl": 30
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": moment().subtract(60, 'seconds').toDate().getTime(),
-        "activeTime": moment().subtract(40, 'seconds').toDate().getTime()
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {}
     },
     {
-        "name": "active not expired",
-        "nodes": [
-            {
-                "nodeName": "green",
-                "algorithmName": "green-alg",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "active not expired",
+            "nodes": [
+                {
+                    "nodeName": "green",
+                    "algorithmName": "green-alg",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug",
+                "ttl": 90,
+                "activeTtl": 50
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": moment().subtract(60, 'seconds').toDate().getTime(),
+            "activeTime": moment().subtract(40, 'seconds').toDate().getTime()
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug",
-            "ttl": 90,
-            "activeTtl": 50
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": moment().subtract(60, 'seconds').toDate().getTime(),
-        "activeTime": moment().subtract(40, 'seconds').toDate().getTime()
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {}
     },
     {
-        "name": "debug4",
-        "nodes": [
-            {
-                "nodeName": "debug-4",
-                "algorithmName": "debug-4",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "debug4",
+            "nodes": [
+                {
+                    "nodeName": "debug-4",
+                    "algorithmName": "debug-4",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug"
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": 1532506623299
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug"
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": 1532506623299
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {}
     },
     {
-        "name": "output4",
-        "nodes": [
-            {
-                "nodeName": "output-4",
-                "algorithmName": "output-4",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "output4",
+            "nodes": [
+                {
+                    "nodeName": "output-4",
+                    "algorithmName": "output-4",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug"
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": 1532506623299
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug"
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": 1532506623299
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {}
     },
     {
-        "name": "gt-alg4",
-        "nodes": [
-            {
-                "nodeName": "gt-alg4",
-                "algorithmName": "gt-alg4",
-                "input": []
-            }
-        ],
-        "flowInput": {
-            "metadata": {},
-            "storageInfo": {
-                "Key": "key1",
-                "Bucket": "hkube"
-            }
+        "pipeline": {
+            "name": "gt-alg4",
+            "nodes": [
+                {
+                    "nodeName": "gt-alg4",
+                    "algorithmName": "gt-alg4",
+                    "input": []
+                }
+            ],
+            "flowInput": {
+                "metadata": {},
+                "storageInfo": {
+                    "Key": "key1",
+                    "Bucket": "hkube"
+                }
+            },
+            "options": {
+                "batchTolerance": 100,
+                "progressVerbosityLevel": "debug"
+            },
+            "webhooks": {
+                "progress": "http://localhost:3003/webhook/progress",
+                "result": "http://localhost:3003/webhook/result"
+            },
+            "priority": 3,
+            "startTime": 1532506623299
         },
-        "options": {
-            "batchTolerance": 100,
-            "progressVerbosityLevel": "debug"
-        },
-        "webhooks": {
-            "progress": "http://localhost:3003/webhook/progress",
-            "result": "http://localhost:3003/webhook/result"
-        },
-        "priority": 3,
-        "startTime": 1532506623299
+        "pdIntervalTimestamp": Date.now(),
+        "graph": {}
     }
 ]

--- a/core/gc-service/tests/setup.js
+++ b/core/gc-service/tests/setup.js
@@ -22,7 +22,13 @@ before(async function () {
     const storeManager = require('../lib/helpers/store-manager');
     await storeManager._db.db.dropDatabase();
     await storeManager._db.init();
-    await storeManager._db.jobs.createMany(executions.map((e, i) => ({ jobId: `job-${i}`, pipeline: e })));
+    await storeManager._db.jobs.createMany(executions.map((e, i) => (
+        { 
+            jobId: `job-${i}`,
+            pipeline: e.pipeline,
+            pdIntervalTimestamp: e.pdIntervalTimestamp,
+            graph: e.graph 
+        })));
 
     global.testParams = {
         config

--- a/core/gc-service/tests/taskStatus/mocks/etcdStore.json
+++ b/core/gc-service/tests/taskStatus/mocks/etcdStore.json
@@ -8,7 +8,7 @@
         "batchIndex": 0,
         "isStateful": false,
         "status": "active",
-        "startTime": 1704180328947,
+        "startTime": 1532506623299,
         "data": {}
     },
     {
@@ -20,7 +20,7 @@
         "batchIndex": 0,
         "isStateful": false,
         "status": "warning",
-        "startTime": 1704180148790,
+        "startTime": 1532506623299,
         "data": {}
     },
     {
@@ -32,7 +32,7 @@
         "batchIndex": 0,
         "isStateful": false,
         "status": "active",
-        "startTime": 1704180151093,
+        "startTime": 1532506623299,
         "data": {}
     },
     {
@@ -44,6 +44,78 @@
         "batchIndex": 0,
         "isStateful": false,
         "status": "warning",
+        "startTime": 1704180132719,
+        "data": {}
+    },
+    {
+        "jobId": "job-5",
+        "taskId": "337w0qdo",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-nfbz8-ntvnc",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "active",
+        "startTime": 1704180132719,
+        "data": {}
+    },
+    {
+        "jobId": "job-6",
+        "taskId": "337w0qdo",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-nfbz8-ntvnc",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "active",
+        "startTime": 1704180132719,
+        "data": {}
+    },
+    {
+        "jobId": "job-7",
+        "taskId": "337w0qdo",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-nfbz8-ntvnc",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "active",
+        "startTime": 1704180132719,
+        "data": {}
+    },
+    {
+        "jobId": "job-8",
+        "taskId": "337w0qdo",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-nfbz8-ntvnc",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "active",
+        "startTime": 1704180132719,
+        "data": {}
+    },
+    {
+        "jobId": "job-9",
+        "taskId": "337w0qdo",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-nfbz8-ntvnc",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "active",
+        "startTime": 1704180132719,
+        "data": {}
+    },
+    {
+        "jobId": "job-10",
+        "taskId": "337w0qdo",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-nfbz8-ntvnc",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "active",
         "startTime": 1704180132719,
         "data": {}
     }

--- a/core/gc-service/tests/taskStatus/mocks/etcdStore.json
+++ b/core/gc-service/tests/taskStatus/mocks/etcdStore.json
@@ -1,0 +1,53 @@
+[
+    {
+        "jobId": "mgwxiwwutafu",
+        "taskId": "so7bw5d9",
+        "nodeName": "stayup4",
+        "algorithmName": "stayup",
+        "podName": "stayup-5a611-9rkc5",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "active",
+        "startTime": 1704180328947,
+        "data": {}
+    },
+    {
+        "jobId": "6rk6vuy9fa3h",
+        "taskId": "6ahx4qad",
+        "nodeName": "stayup",
+        "algorithmName": "stayup",
+        "podName": "stayup-ygzyl-hlgtk",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "warning",
+        "startTime": 1704180148790,
+        "data": {}
+    },
+    {
+        "jobId": "kez7s5xl5gfm",
+        "taskId": "q8sismx6",
+        "nodeName": "stayup3",
+        "algorithmName": "stayup",
+        "podName": "stayup-rn7ph-24q9k",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "active",
+        "startTime": 1704180151093,
+        "data": {}
+    },
+    {
+        "jobId": "h9sgsskbgbmr",
+        "taskId": "337w0qdo",
+        "nodeName": "stayup2",
+        "algorithmName": "stayup",
+        "podName": "stayup-nfbz8-ntvnc",
+        "batchIndex": 0,
+        "isStateful": false,
+        "status": "warning",
+        "startTime": 1704180132719,
+        "data": {}
+    }
+    
+
+
+]

--- a/core/gc-service/tests/taskStatus/mocks/etcdStore.json
+++ b/core/gc-service/tests/taskStatus/mocks/etcdStore.json
@@ -1,10 +1,10 @@
 [
     {
-        "jobId": "mgwxiwwutafu",
+        "jobId": "job-1",
         "taskId": "so7bw5d9",
-        "nodeName": "stayup4",
-        "algorithmName": "stayup",
-        "podName": "stayup-5a611-9rkc5",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-5a611-9rkc5",
         "batchIndex": 0,
         "isStateful": false,
         "status": "active",
@@ -12,11 +12,11 @@
         "data": {}
     },
     {
-        "jobId": "6rk6vuy9fa3h",
+        "jobId": "job-2",
         "taskId": "6ahx4qad",
-        "nodeName": "stayup",
-        "algorithmName": "stayup",
-        "podName": "stayup-ygzyl-hlgtk",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-ygzyl-hlgtk",
         "batchIndex": 0,
         "isStateful": false,
         "status": "warning",
@@ -24,11 +24,11 @@
         "data": {}
     },
     {
-        "jobId": "kez7s5xl5gfm",
+        "jobId": "job-3",
         "taskId": "q8sismx6",
-        "nodeName": "stayup3",
-        "algorithmName": "stayup",
-        "podName": "stayup-rn7ph-24q9k",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-rn7ph-24q9k",
         "batchIndex": 0,
         "isStateful": false,
         "status": "active",
@@ -36,11 +36,11 @@
         "data": {}
     },
     {
-        "jobId": "h9sgsskbgbmr",
+        "jobId": "job-4",
         "taskId": "337w0qdo",
-        "nodeName": "stayup2",
-        "algorithmName": "stayup",
-        "podName": "stayup-nfbz8-ntvnc",
+        "nodeName": "green",
+        "algorithmName": "green-alg",
+        "podName": "green-nfbz8-ntvnc",
         "batchIndex": 0,
         "isStateful": false,
         "status": "warning",

--- a/core/gc-service/tests/taskStatus/mocks/etcdStore.json
+++ b/core/gc-service/tests/taskStatus/mocks/etcdStore.json
@@ -20,6 +20,7 @@
         "batchIndex": 0,
         "isStateful": false,
         "status": "warning",
+        "warning": "unable to connect redis at 100.70.85.112:26379",
         "startTime": 1532506623299,
         "data": {}
     },
@@ -44,6 +45,7 @@
         "batchIndex": 0,
         "isStateful": false,
         "status": "warning",
+        "warning": "unable to connect redis at 100.70.85.112:26379",
         "startTime": 1704180132719,
         "data": {}
     },

--- a/core/gc-service/tests/taskStatus/test.js
+++ b/core/gc-service/tests/taskStatus/test.js
@@ -4,9 +4,10 @@ const { expect } = chai;
 describe('Task Status', () => {
     before(async () => {
         storeManager = require('../../lib/helpers/store-manager');
+        cleanerManager = require('../../lib/core/cleaner-manager');
+        cleaner = cleanerManager.getCleaner('taskStatus');
     });
     it.skip('should change status to warning in db', async () => {
-        const x = 'something';
-            expect(x).to.eq('something');
+
     })
 })

--- a/core/gc-service/tests/taskStatus/test.js
+++ b/core/gc-service/tests/taskStatus/test.js
@@ -18,7 +18,7 @@ describe('Task Status', () => {
     });
     it('should change status to warning in db', async () => {
         etcdMock.reset();
-        jobIds = await cleaner.clean(1000);
+        jobIds = await cleaner.clean();
         expect(jobIds.length).to.equal(2);
         
     })

--- a/core/gc-service/tests/taskStatus/test.js
+++ b/core/gc-service/tests/taskStatus/test.js
@@ -1,13 +1,25 @@
 const chai = require('chai');
 const { expect } = chai;
+const etcdMock = require('../etcd/mocks/etcd-store')
+const executions = require('../pipelines/mocks/executions');
 
 describe('Task Status', () => {
     before(async () => {
         storeManager = require('../../lib/helpers/store-manager');
         cleanerManager = require('../../lib/core/cleaner-manager');
         cleaner = cleanerManager.getCleaner('taskStatus');
+        await storeManager._db.jobs.createMany(executions.map((e, i) => (
+            { 
+                jobId: `job-${i}`,
+                pipeline: e.pipeline,
+                pdIntervalTimestamp: e.pdIntervalTimestamp,
+                graph: e.graph 
+            })));
     });
-    it.skip('should change status to warning in db', async () => {
-
+    it('should change status to warning in db', async () => {
+        etcdMock.reset();
+        jobIds = await cleaner.clean(1000);
+        expect(jobIds.length).to.equal(2);
+        
     })
 })

--- a/core/gc-service/tests/taskStatus/test.js
+++ b/core/gc-service/tests/taskStatus/test.js
@@ -20,6 +20,12 @@ describe('Task Status', () => {
         etcdMock.reset();
         jobIds = await cleaner.clean();
         expect(jobIds.length).to.equal(2);
+               jobIds.forEach(async (job) => {
+            const graph = await storeManager._db.jobs.fetchGraph({jobId: job})
+            expect(graph.nodes[0].status).to.eql('warning');
+                
+        })
+
         
     })
 })

--- a/core/gc-service/tests/taskStatus/test.js
+++ b/core/gc-service/tests/taskStatus/test.js
@@ -1,0 +1,12 @@
+const chai = require('chai');
+const { expect } = chai;
+
+describe('Task Status', () => {
+    before(async () => {
+        storeManager = require('../../lib/helpers/store-manager');
+    });
+    it.skip('should change status to warning in db', async () => {
+        const x = 'something';
+            expect(x).to.eq('something');
+    })
+})

--- a/core/pipeline-driver/bootstrap.js
+++ b/core/pipeline-driver/bootstrap.js
@@ -16,7 +16,7 @@ const modules = [
     require('./lib/datastore/graph-store'),
     require('./lib/consumer/jobs-consumer')
 ];
-
+// testing git husky precommit hook
 class Bootstrap {
     async init() {
         try {

--- a/core/pipeline-driver/bootstrap.js
+++ b/core/pipeline-driver/bootstrap.js
@@ -16,7 +16,7 @@ const modules = [
     require('./lib/datastore/graph-store'),
     require('./lib/consumer/jobs-consumer')
 ];
-// testing git husky precommit hook
+
 class Bootstrap {
     async init() {
         try {

--- a/core/pipeline-driver/lib/datastore/graph-store.js
+++ b/core/pipeline-driver/lib/datastore/graph-store.js
@@ -5,6 +5,7 @@ const flatten = require('flat');
 const log = require('@hkube/logger').GetLogFromContainer();
 const { Persistency } = require('@hkube/dag');
 const { taskStatuses } = require('@hkube/consts');
+const db = require('../state/db');
 const components = require('../consts/componentNames');
 const INTERVAL = 4000;
 const persistency = new Persistency();
@@ -58,6 +59,7 @@ class GraphStore {
             if (this._nodesMap) {
                 const graph = this._nodesMap.getJSONGraph();
                 await this._updateGraph(graph);
+                await db.updatePdIntervalTimestamp(this._jobId);
             }
         }
         catch (error) {

--- a/core/pipeline-driver/lib/state/db.js
+++ b/core/pipeline-driver/lib/state/db.js
@@ -20,6 +20,10 @@ class DB {
         return error;
     }
 
+    async updatePdIntervalTimestamp(jobId) {
+        await this._db.jobs.updatePdIntervalTimestamp(jobId);
+    }
+
     async updateResult(options) {
         return this._db.jobs.updateResult(options);
     }
@@ -49,7 +53,7 @@ class DB {
     }
 
     _wrapJobsService() {
-        ['updateResult', 'updateStatus', 'fetchStatus', 'fetchPipeline', 'updatePipeline', 'createJob'].forEach(propertyName => {
+        ['updateResult', 'updateStatus', 'fetchStatus', 'fetchPipeline', 'updatePipeline', 'createJob', 'updatePdIntervalTimestamp'].forEach(propertyName => {
             if (typeof this._db.jobs[propertyName] === 'function') {
                 this[propertyName] = this._wrapperForDBProblem(this[propertyName]);
             }

--- a/core/pipeline-driver/package-lock.json
+++ b/core/pipeline-driver/package-lock.json
@@ -12,7 +12,7 @@
         "@hkube/config": "^2.0.11",
         "@hkube/consts": "^1.0.38",
         "@hkube/dag": "^2.2.2",
-        "@hkube/db": "^2.0.12",
+        "@hkube/db": "^2.0.14",
         "@hkube/etcd": "^5.1.9",
         "@hkube/logger": "^2.0.2",
         "@hkube/metrics": "^1.0.42",
@@ -703,9 +703,9 @@
       "integrity": "sha512-iRv10nt2Eu9ey8S3sgTtmwAaZEy87XCLBhP5f9xs4/gg3PxTV3aX/ORj3TX2yv7MkdKwx0cBaKSZML7GdQb38Q=="
     },
     "node_modules/@hkube/db": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@hkube/db/-/db-2.0.12.tgz",
-      "integrity": "sha512-97j9HywDYkag5qP4Ug6iYzG84PJHFPUflfWewHVv0hnhROe2Te4Y0ip54bqg8CfNpUaRAiDhmsm3Tl1RlbeWLQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@hkube/db/-/db-2.0.14.tgz",
+      "integrity": "sha512-t60HPQ6R0J8MP9M6bOx2WwZB0rODbsv36a3f2xBd99/Qx/FVRpLaBmqsC6rFDUBuJr3M42iGejk5xsxY3c7gTg==",
       "dependencies": {
         "@hkube/consts": "^1.0.40",
         "lodash.clonedeep": "^4.5.0",

--- a/core/pipeline-driver/package.json
+++ b/core/pipeline-driver/package.json
@@ -11,7 +11,7 @@
     "@hkube/config": "^2.0.11",
     "@hkube/consts": "^1.0.38",
     "@hkube/dag": "^2.2.2",
-    "@hkube/db": "^2.0.12",
+    "@hkube/db": "^2.0.14",
     "@hkube/etcd": "^5.1.9",
     "@hkube/logger": "^2.0.2",
     "@hkube/metrics": "^1.0.42",

--- a/core/worker/bootstrap.js
+++ b/core/worker/bootstrap.js
@@ -28,7 +28,7 @@ const modules = [
     require('./lib/storage/storage.js'),
     require('./lib/streaming/services/stream-handler.js'),
 ];
-// testing git husky precommit hooks 
+
 class Bootstrap {
     async init() {
         try {

--- a/core/worker/bootstrap.js
+++ b/core/worker/bootstrap.js
@@ -9,6 +9,7 @@ const monitor = require('@hkube/redis-utils').Monitor;
 const storageManager = require('@hkube/storage-manager');
 const component = require('./lib/consts').Components.MAIN;
 const worker = require('./lib/worker');
+const jobConsumer = require('./lib/consumer/JobConsumer.js');
 
 const modules = [
     require('./lib/metrics/metrics.js'),
@@ -39,6 +40,7 @@ class Bootstrap {
             });
             monitor.on('close', (data) => {
                 log.error(data.error.message, { component });
+                jobConsumer.sendWarning(data.error.message);
                 worker.handleExit(1);
             });
             await monitor.check(main.redis);

--- a/core/worker/bootstrap.js
+++ b/core/worker/bootstrap.js
@@ -28,7 +28,7 @@ const modules = [
     require('./lib/storage/storage.js'),
     require('./lib/streaming/services/stream-handler.js'),
 ];
-
+// testing git husky precommit hooks 
 class Bootstrap {
     async init() {
         try {

--- a/core/worker/bootstrap.js
+++ b/core/worker/bootstrap.js
@@ -41,6 +41,7 @@ class Bootstrap {
             monitor.on('close', (data) => {
                 log.error(data.error.message, { component });
                 jobConsumer.sendWarning(data.error.message);
+                log.message('The status has been changed to warning')
                 worker.handleExit(1);
             });
             await monitor.check(main.redis);

--- a/core/worker/bootstrap.js
+++ b/core/worker/bootstrap.js
@@ -41,7 +41,7 @@ class Bootstrap {
             monitor.on('close', (data) => {
                 log.error(data.error.message, { component });
                 jobConsumer.sendWarning(data.error.message);
-                log.message('The status has been changed to warning')
+                log.info('The status has been changed to warning')
                 worker.handleExit(1);
             });
             await monitor.check(main.redis);

--- a/core/worker/bootstrap.js
+++ b/core/worker/bootstrap.js
@@ -41,7 +41,6 @@ class Bootstrap {
             monitor.on('close', (data) => {
                 log.error(data.error.message, { component });
                 jobConsumer.sendWarning(data.error.message);
-                log.info('The status has been changed to warning')
                 worker.handleExit(1);
             });
             await monitor.check(main.redis);


### PR DESCRIPTION
When all Redis pods stop working the pipelines that are running stop working, but it only shows this as a warning in the Etcd but this warning does not transfer to mongodb so it does not show the user that there are tasks in a warning status.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/1853)
<!-- Reviewable:end -->
