### PR TITLE
Feature algorithms notify unfulfilled hot workers

### DIFF
--- a/core/api-server/api/graphql/schemas/algorithm-schema.js
+++ b/core/api-server/api/graphql/schemas/algorithm-schema.js
@@ -16,6 +16,7 @@ type GitRepository { gitKind: String
 type Algorithm { 
  
   name: String
+  isSatisfied: Boolean
   cpu: String
   created: Float
   entryPoint: String

--- a/core/api-server/lib/state/state-manager.js
+++ b/core/api-server/lib/state/state-manager.js
@@ -111,13 +111,25 @@ class StateManager extends EventEmitter {
     }
 
     async getAlgorithms({ name, names, kind, sort, limit } = {}) {
-        return this._db.algorithms.search({
+        const allAlgorithms = await this._db.algorithms.search({
             name,
             names,
             kind,
             sort: { created: sort },
             limit
         });
+        // This section handles algorithms that are not satisfied, which may occur under the following conditions:
+        // 1 - Insufficient CPU/GPU/Memory for a hot worker to start.
+        // 2 - When a job is running, there are not enough resources for the worker to run the algorithm.
+        const taskExecuter = await this.getSystemResources();
+        const updatedAlgorithms = allAlgorithms.map(algo => {
+            if (taskExecuter && taskExecuter[0] && taskExecuter[0].ignoredUnScheduledAlgorithms) {
+                const isIgnored = taskExecuter[0].ignoredUnScheduledAlgorithms[algo.name] !== undefined;
+                return { ...algo, isSatisfied: !isIgnored };
+            }
+            return { ...algo, isSatisfied: true };
+        });
+        return updatedAlgorithms;
     }
 
     async searchAlgorithms({ name, kind, algorithmImage, pending, cursor, page, sort, limit, fields } = {}) {

--- a/core/api-server/lib/state/state-manager.js
+++ b/core/api-server/lib/state/state-manager.js
@@ -123,8 +123,9 @@ class StateManager extends EventEmitter {
         // 2 - When a job is running, there are not enough resources for the worker to run the algorithm.
         const taskExecuter = await this.getSystemResources();
         const updatedAlgorithms = allAlgorithms.map(algo => {
-            if (taskExecuter && taskExecuter[0] && taskExecuter[0].ignoredUnScheduledAlgorithms) {
-                const isIgnored = taskExecuter[0].ignoredUnScheduledAlgorithms[algo.name] !== undefined;
+            if (taskExecuter && taskExecuter[0] && taskExecuter[0].ignoredUnScheduledAlgorithms && taskExecuter[0].unScheduledAlgorithms) {
+                const unScheduledAndIgnored = { ...taskExecuter[0].unScheduledAlgorithms, ...taskExecuter[0].ignoredUnScheduledAlgorithms };
+                const isIgnored = unScheduledAndIgnored[algo.name] !== undefined;
                 return { ...algo, isSatisfied: !isIgnored };
             }
             return { ...algo, isSatisfied: true };

--- a/core/api-server/lib/validation/algorithms.js
+++ b/core/api-server/lib/validation/algorithms.js
@@ -41,6 +41,8 @@ class ApiValidator {
         this._validator.validate(this._validator.definitions.algorithmDelete, algorithm, true);
     }
 
+    // This method checks if the given algorithm can run on a node with sufficient resources.
+    // Note: The availability of free resources is not guaranteed.
     async validateAlgorithmResources(algorithm) {
         const resources = await stateManager.getSystemResources();
         if (resources && resources[0] && resources[0].nodes) {


### PR DESCRIPTION
Added a new field to the algorithm object indicating whether it is satisfied or not.
A satisfied algorithm means the algorithm has no issues running the necessary workers.
This field needs to be addressed in the UI.
Related Issue: kube-HPC/hkube#1811

For the UI, the new query should request the value `isSatisfied`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/1960)
<!-- Reviewable:end -->
