### PR TITLE
updated to receive message and not just status

### DIFF
--- a/core/api-server/lib/state/state-manager.js
+++ b/core/api-server/lib/state/state-manager.js
@@ -127,8 +127,8 @@ class StateManager extends EventEmitter {
             ...taskExecuter[0]?.ignoredUnScheduledAlgorithms
         } : {};
         const updatedAlgorithms = allAlgorithms.map(algo => {
-            const message = unScheduledAndIgnored[algo.name] ? unScheduledAndIgnored[algo.name].message : undefined;
-            return { ...algo, message };
+            const unscheduledReason = unScheduledAndIgnored[algo.name] ? unScheduledAndIgnored[algo.name].message : undefined;
+            return { ...algo, unscheduledReason };
         });
         return updatedAlgorithms;
     }

--- a/core/api-server/lib/state/state-manager.js
+++ b/core/api-server/lib/state/state-manager.js
@@ -127,8 +127,8 @@ class StateManager extends EventEmitter {
             ...taskExecuter[0]?.ignoredUnScheduledAlgorithms
         } : {};
         const updatedAlgorithms = allAlgorithms.map(algo => {
-            const isIgnored = unScheduledAndIgnored[algo.name] !== undefined;
-            return { ...algo, isSatisfied: !isIgnored };
+            const message = unScheduledAndIgnored[algo.name] ? unScheduledAndIgnored[algo.name].message : undefined;
+            return { ...algo, message };
         });
         return updatedAlgorithms;
     }


### PR DESCRIPTION
Now, instead of prop `isSatisfied` we take the last message indicating why the algorithm is not satisfied.
If the algorithm is satisfied, the message is undefined.
Related issue: kube-HPC/hkube#1970

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/1971)
<!-- Reviewable:end -->
