### PR TITLE
Feature max cpu/mem/gpu

### DIFF
--- a/core/api-server/lib/validation/algorithms.js
+++ b/core/api-server/lib/validation/algorithms.js
@@ -59,19 +59,25 @@ class ApiValidator {
 
     _createAlgorithmResourcesError(nodes) {
         const maxCapacityMap = Object.create(null);
-
+        let nodeNumber = 0;
         nodes.forEach(n => {
+            const nodeTotal = n.node.total;
             Object.entries(n.details)
                 .filter(([, v]) => v === false)
                 .forEach(([k]) => {
                     if (!maxCapacityMap[k]) {
-                        maxCapacityMap[k] = 0;
+                        maxCapacityMap[k] = Object.create(null);
                     }
-                    maxCapacityMap[k] += 1;
+                    maxCapacityMap[k][nodeNumber] = nodeTotal[k];
                 });
+            nodeNumber += 1;
         });
-
-        const maxCapacity = Object.entries(maxCapacityMap).map(([k, v]) => `${k} (${v} nodes)`);
+        const maxCapacity = Object.entries(maxCapacityMap).map(([resourceType, nodeData]) => {
+            const nodeDetails = Object.entries(nodeData)
+                .map(([nodeIndex, capacity]) => `node${+nodeIndex + 1}:${capacity}`)
+                .join(', ');
+            return `${resourceType}(${nodeDetails})`;
+        });
         const error = `maximum capacity exceeded ${maxCapacity.join(', ')}`;
         return error;
     }

--- a/core/api-server/tests/algorithms-store.js
+++ b/core/api-server/tests/algorithms-store.js
@@ -805,7 +805,7 @@ describe('Store/Algorithms', () => {
                 };
                 const res = await request(options);
                 expect(res.body.error.code).to.equal(HttpStatus.BAD_REQUEST);
-                expect(res.body.error.message).to.eql(`maximum capacity exceeded cpu (4 nodes)`);
+                expect(res.body.error.message).to.eql(`maximum capacity exceeded cpu(node1:15, node2:16, node3:17, node4:18)`);
             });
             it('should throw validation error of maximum mem capacity exceeded', async () => {
                 const body = {
@@ -820,7 +820,7 @@ describe('Store/Algorithms', () => {
                 };
                 const res = await request(options);
                 expect(res.body.error.code).to.equal(HttpStatus.BAD_REQUEST);
-                expect(res.body.error.message).to.eql(`maximum capacity exceeded mem (4 nodes)`);
+                expect(res.body.error.message).to.eql(`maximum capacity exceeded mem(node1:40805, node2:50805, node3:60805, node4:70805)`);
             });
             it('should throw validation error of maximum capacity exceeded all', async () => {
                 const body = {
@@ -835,7 +835,7 @@ describe('Store/Algorithms', () => {
                 };
                 const res = await request(options);
                 expect(res.body.error.code).to.equal(HttpStatus.BAD_REQUEST);
-                expect(res.body.error.message).to.eql(`maximum capacity exceeded cpu (4 nodes), mem (4 nodes), gpu (4 nodes)`);
+                expect(res.body.error.message).to.eql(`maximum capacity exceeded cpu(node1:15, node2:16, node3:17, node4:18), mem(node1:40805, node2:50805, node3:60805, node4:70805), gpu(node1:0, node2:1, node3:2, node4:3)`);
             });
             it('should delete nullable properties', async () => {
                 const algorithmName = uuid();


### PR DESCRIPTION
Updated error message to have more details.
Example:
"maximum capacity exceeded cpu(node1:15, node2:16, node3:17, node4:18)"
indicates we exceeded the capacity of cpu in node1 (which has a maximum of 15), etc.
Issue: kube-HPC/hkube#1966

Tests updated as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/1972)
<!-- Reviewable:end -->
