### PR TITLE
Bug wrapper algorunner out of memory

### DIFF
--- a/core/worker/config/main/config.base.js
+++ b/core/worker/config/main/config.base.js
@@ -197,4 +197,6 @@ config.cacheResults = {
 config.disableCache = formatters.parseBool(process.env.DISABLE_WORKER_CACHE, false);
 config.algoMetricsDir = process.env.ALGO_METRICS_DIR || '/var/metrics/';
 
+config.wrapperTimeoutDuration = 10000;
+
 module.exports = config;

--- a/core/worker/config/main/config.base.js
+++ b/core/worker/config/main/config.base.js
@@ -197,6 +197,6 @@ config.cacheResults = {
 config.disableCache = formatters.parseBool(process.env.DISABLE_WORKER_CACHE, false);
 config.algoMetricsDir = process.env.ALGO_METRICS_DIR || '/var/metrics/';
 
-config.wrapperTimeoutDuration = 10000;
+config.wrapperTimeoutDuration = process.env.WRAPPER_TIMEOUT_DURATION || 10000;
 
 module.exports = config;

--- a/core/worker/lib/algorithm-communication/messages.js
+++ b/core/worker/lib/algorithm-communication/messages.js
@@ -17,7 +17,8 @@ module.exports = {
         stopAlgorithmExecution: 'stopAlgorithmExecution',
         streamingStatistics: 'streamingStatistics',
         storing: 'storing',
-        done: 'done'
+        done: 'done',
+        alive: 'alive'
     },
     outgoing: {
         initialize: 'initialize',

--- a/core/worker/lib/algorithm-communication/workerCommunication.js
+++ b/core/worker/lib/algorithm-communication/workerCommunication.js
@@ -41,7 +41,8 @@ class WorkerCommunication extends EventEmitter {
         this.adapter = new AdapterClass();
         this._printThrottleMessages = {
             [messages.incomming.stopping]: { delay: 10000, lastPrint: null },
-            [messages.incomming.streamingStatistics]: { delay: 30000, lastPrint: null }
+            [messages.incomming.streamingStatistics]: { delay: 30000, lastPrint: null },
+            [messages.incomming.alive]: { delay: 10000 * 30, lastPrint: null }
         };
         Object.entries({ ...messages.incomming, connection: 'connection', disconnect: 'disconnect' }).forEach(([, topic]) => {
             log.debug(`registering for topic ${topic}`, { component });
@@ -55,20 +56,16 @@ class WorkerCommunication extends EventEmitter {
 
     _printThrottle(topic, message) {
         const setting = this._printThrottleMessages[topic];
-        let shouldPrint = true;
         if (setting) {
             const { delay, lastPrint } = setting;
             if (lastPrint === null || Date.now() - lastPrint > delay) {
-                shouldPrint = true;
                 setting.lastPrint = Date.now();
             }
             else {
-                shouldPrint = false;
+                return;
             }
         }
-        if (shouldPrint) {
-            log.info(`got message on topic ${topic}, command: ${message && message.command}`, { component });
-        }
+        log.info(`got message on topic ${topic}, command: ${message && message.command}`, { component });
     }
 
     setEncodingType(type) {

--- a/core/worker/lib/worker.js
+++ b/core/worker/lib/worker.js
@@ -324,7 +324,7 @@ class Worker {
         algoRunnerCommunication.on(messages.incomming.done, (message) => {
             stateManager.done(message);
             this._wrapperAlive.isRunning = false;
-            clearTimeout(this._wrapperAlive.inactiveTime);
+            clearTimeout(this._wrapperAlive.inactiveTimer);
         });
         algoRunnerCommunication.on(messages.incomming.stopped, (message) => {
             if (this._stopTimeout) {
@@ -559,14 +559,14 @@ class Worker {
 
     /**
      * Sets or resets a timeout to check if the wrapper is still alive.
-     * The timeout duration is defined by `this._wrapperAlive.inactiveTime`.
+     * The timeout duration is defined by `this._wrapperAlive.inactiveTimer`.
      */
     _handleWrapperIsAlive() {
         if (this._wrapperAlive.isRunning) {
-            if (this._wrapperAlive.inactiveTime) {
-                clearTimeout(this._wrapperAlive.inactiveTime);
+            if (this._wrapperAlive.inactiveTimer) {
+                clearTimeout(this._wrapperAlive.inactiveTimer);
             }
-            this._wrapperAlive.inactiveTime = setTimeout(() => {
+            this._wrapperAlive.inactiveTimer = setTimeout(() => {
                 log.info(`No response from wrapper for more than ${this._wrapperAlive.timeoutDuration / 1000} seconds.`, { component });
                 stateManager.error();
             }, this._wrapperAlive.timeoutDuration);

--- a/core/worker/lib/worker.js
+++ b/core/worker/lib/worker.js
@@ -33,13 +33,6 @@ class Worker {
         this._wrapperAlive = {};
     }
 
-    _initWrapperSettings(timeoutDuration = 10000) {
-        this._wrapperAlive = {
-            isRunning: false,
-            timeoutDuration
-        };
-    }
-
     preInit(options) {
         log = Logger.GetLogFromContainer();
         this._registerToConnectionEvents();
@@ -59,6 +52,13 @@ class Worker {
         this._registerToAutoScalerChangesEvents();
         this._setInactiveTimeout();
         this._doTheBootstrap();
+    }
+
+    _initWrapperSettings(timeoutDuration) {
+        this._wrapperAlive = {
+            isRunning: false,
+            timeoutDuration
+        };
     }
 
     _initAlgorithmSettings() {

--- a/core/worker/lib/worker.js
+++ b/core/worker/lib/worker.js
@@ -33,12 +33,9 @@ class Worker {
         this._wrapperAlive = {};
     }
 
-    _initWrapperSettings({
-        isRunning = false,
-        timeoutDuration = 10000
-    } = {}) {
+    _initWrapperSettings(timeoutDuration = 10000) {
         this._wrapperAlive = {
-            isRunning,
+            isRunning: false,
             timeoutDuration
         };
     }
@@ -52,7 +49,7 @@ class Worker {
         this._servingReportInterval = options.servingReportInterval;
         this._stopTimeoutMs = options.timeouts.stop || DEFAULT_STOP_TIMEOUT;
         this._stoppingTimeoutMs = options.timeouts.stoppingTimeoutMs;
-        this._initWrapperSettings();
+        this._initWrapperSettings(options.wrapperTimeoutDuration);
     }
 
     async init() {

--- a/core/worker/lib/worker.js
+++ b/core/worker/lib/worker.js
@@ -567,7 +567,7 @@ class Worker {
                 clearTimeout(this._wrapperAlive.inactiveTimer);
             }
             this._wrapperAlive.inactiveTimer = setTimeout(() => {
-                log.info(`No response from wrapper for more than ${this._wrapperAlive.timeoutDuration / 1000} seconds.`, { component });
+                log.error(`No response from wrapper for more than ${this._wrapperAlive.timeoutDuration / 1000} seconds.`, { component });
                 stateManager.error();
             }, this._wrapperAlive.timeoutDuration);
         }


### PR DESCRIPTION
This PR is fixing the bug in the following issue: kube-HPC/hkube#1975
Now, the worker is receiving a new message from the wrapper:  `alive`
And this way the worker knows the wrapper is still up.
The message will be displayed in the log every 30 worker checks (5 minutes).
Also, the method `_printThrottle(topic, message)` has been refactored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/1978)
<!-- Reviewable:end -->
