### PR TITLE
added spacing to error message

### DIFF
--- a/core/api-server/lib/validation/algorithms.js
+++ b/core/api-server/lib/validation/algorithms.js
@@ -74,7 +74,7 @@ class ApiValidator {
         });
         const maxCapacity = Object.entries(maxCapacityMap).map(([resourceType, nodeData]) => {
             const nodeDetails = Object.entries(nodeData)
-                .map(([nodeIndex, capacity]) => `node${+nodeIndex + 1}:${capacity}`)
+                .map(([nodeIndex, capacity]) => `node${+nodeIndex + 1}: ${capacity}`)
                 .join(', ');
             return `${resourceType}(${nodeDetails})`;
         });

--- a/core/api-server/tests/algorithms-store.js
+++ b/core/api-server/tests/algorithms-store.js
@@ -805,7 +805,7 @@ describe('Store/Algorithms', () => {
                 };
                 const res = await request(options);
                 expect(res.body.error.code).to.equal(HttpStatus.BAD_REQUEST);
-                expect(res.body.error.message).to.eql(`maximum capacity exceeded cpu(node1:15, node2:16, node3:17, node4:18)`);
+                expect(res.body.error.message).to.eql(`maximum capacity exceeded cpu(node1: 15, node2: 16, node3: 17, node4: 18)`);
             });
             it('should throw validation error of maximum mem capacity exceeded', async () => {
                 const body = {
@@ -820,7 +820,7 @@ describe('Store/Algorithms', () => {
                 };
                 const res = await request(options);
                 expect(res.body.error.code).to.equal(HttpStatus.BAD_REQUEST);
-                expect(res.body.error.message).to.eql(`maximum capacity exceeded mem(node1:40805, node2:50805, node3:60805, node4:70805)`);
+                expect(res.body.error.message).to.eql(`maximum capacity exceeded mem(node1: 40805, node2: 50805, node3: 60805, node4: 70805)`);
             });
             it('should throw validation error of maximum capacity exceeded all', async () => {
                 const body = {
@@ -835,7 +835,7 @@ describe('Store/Algorithms', () => {
                 };
                 const res = await request(options);
                 expect(res.body.error.code).to.equal(HttpStatus.BAD_REQUEST);
-                expect(res.body.error.message).to.eql(`maximum capacity exceeded cpu(node1:15, node2:16, node3:17, node4:18), mem(node1:40805, node2:50805, node3:60805, node4:70805), gpu(node1:0, node2:1, node3:2, node4:3)`);
+                expect(res.body.error.message).to.eql(`maximum capacity exceeded cpu(node1: 15, node2: 16, node3: 17, node4: 18), mem(node1: 40805, node2: 50805, node3: 60805, node4: 70805), gpu(node1: 0, node2: 1, node3: 2, node4: 3)`);
             });
             it('should delete nullable properties', async () => {
                 const algorithmName = uuid();


### PR DESCRIPTION
Added spacing to error message as required:
> Add spaces in message.
Instead of (node1:8,node2:8....
State: (node1: 8, node2: 8,...

Issue: kube-HPC/hkube#1966

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2020)
<!-- Reviewable:end -->
