### PR TITLE
Get init logs

### DIFF
--- a/core/api-server/api/task-logs/es.js
+++ b/core/api-server/api/task-logs/es.js
@@ -51,9 +51,6 @@ class EsLogs {
 
     async getLogs({ taskId, nodeKind, podName, logMode, sort, limit, skip, searchWord, taskTime, containerNameList }) {
         const query = [];
-        if (taskId) {
-            query.push(`${this._structuredPrefix}meta.internal.taskId: "${taskId}"`);
-        }
         if (podName) {
             query.push(`kubernetes.pod_name: "${podName}"`);
         }
@@ -69,7 +66,7 @@ class EsLogs {
             break;
         }
         // Handle components
-        if (logMode === logModes.SIDECAR) { // In this case, we only ask for 1 sideCar, not more.
+        if (logMode === logModes.SIDECAR) { // In this case, it's possible to ask for 1 sideCar only.
             if (containerNameList.length === 0) {
                 log.error('a sideCar Name is requried in containerNames when logMode is SIDECAR!', { component });
                 return [];
@@ -88,23 +85,18 @@ class EsLogs {
             query.push(`${searchWord}*`);
         }
 
+        let queryStringNoTaskId;
+        if (logMode !== logModes.INTERNAL && logMode !== logModes.ALGORITHM) {
+            queryStringNoTaskId = query.join(' AND ');
+        }
+
+        if (taskId) {
+            query.push(`${this._structuredPrefix}meta.internal.taskId: "${taskId}"`);
+        }
+
         const queryString = query.join(' AND ');
 
-        const body = {
-            size: limit,
-            from: skip,
-            sort: [{ [`${this._structuredPrefix}meta.timestamp`]: { order: sort } }],
-            _source: [`${this._structuredPrefix}message`, 'level', `${this._structuredPrefix}meta.timestamp`],
-            query: {
-                bool: {
-                    must: [{
-                        query_string: {
-                            query: queryString
-                        }
-                    }]
-                }
-            }
-        };
+        const body = this._buildBody(limit, skip, sort, queryString);
 
         // add range date
         if (taskTime) {
@@ -123,12 +115,48 @@ class EsLogs {
             type: this._type,
             body
         });
+
         if (this._structuredPrefix) {
             logs.hits = logs.hits.map(line => ({
                 ...line, ...line[this._structuredPrefixAtrributeName]
             }));
         }
+
+        if (queryStringNoTaskId) {
+            const bodyNoTaskId = this._buildBody(limit, skip, sort, queryStringNoTaskId);
+            const logsNoTaskId = await this._client.search({
+                index: this._index,
+                type: this._type,
+                body: bodyNoTaskId
+            });
+            if (this._structuredPrefix) {
+                logsNoTaskId.hits = logsNoTaskId.hits.map(line => ({
+                    ...line, ...line[this._structuredPrefixAtrributeName]
+                }));
+            }
+            return [...logs.hits, ...logsNoTaskId.hits];
+        }
+
         return logs.hits;
+    }
+
+    _buildBody(size, from, sort, queryString) {
+        const body = {
+            size,
+            from,
+            sort: [{ [`${this._structuredPrefix}meta.timestamp`]: { order: sort } }],
+            _source: [`${this._structuredPrefix}message`, 'level', `${this._structuredPrefix}meta.timestamp`],
+            query: {
+                bool: {
+                    must: [{
+                        query_string: {
+                            query: queryString
+                        }
+                    }]
+                }
+            }
+        };
+        return body;
     }
 }
 

--- a/core/api-server/api/task-logs/kubernetes.js
+++ b/core/api-server/api/task-logs/kubernetes.js
@@ -118,7 +118,12 @@ class KubernetesLogs {
             const { taskId, component: logComponent } = line.meta.internal;
             if (task) {
                 const resolvedSearchComponent = [...getSearchComponent(nodeKind), ...containerNameList];
-                if (task === taskId && resolvedSearchComponent.includes(logComponent)) {
+                if (taskId) {
+                    if (task === taskId && resolvedSearchComponent.includes(logComponent)) {
+                        return line;
+                    }
+                }
+                else if (resolvedSearchComponent.includes(logComponent)) { // case when sideCar container starts before jobID is given.
                     return line;
                 }
             }

--- a/core/worker/lib/algorithm-logging/logging-proxy.js
+++ b/core/worker/lib/algorithm-logging/logging-proxy.js
@@ -242,7 +242,7 @@ class LoggingProxy {
     _startComponentWatch(logFilePath, component) {
         if (!logFilePath) return;
         if (!fs.existsSync(logFilePath)) {
-            log.throttle.warning(`Log file ${logFilePath} does not exist. Trying again it ${DELAY} seconds.`, { component });
+            log.throttle.warning(`Log file ${logFilePath} does not exist. Trying again it ${DELAY} seconds.`, { workerComponent });
             setTimeout(() => this._startComponentWatch(logFilePath, component), DELAY * 1000);
             return;
         }
@@ -256,7 +256,7 @@ class LoggingProxy {
             });
         }
         catch (error) {
-            log.throttle.warning(`Logging proxy error: ${error.message}. Trying again in ${DELAY} seconds.`, { component });
+            log.throttle.warning(`Logging proxy error: ${error.message}. Trying again in ${DELAY} seconds.`, { workerComponent });
             setTimeout(() => this._startComponentWatch(logFilePath, component), DELAY * 1000);
         }
     }

--- a/core/worker/lib/algorithm-logging/logging-proxy.js
+++ b/core/worker/lib/algorithm-logging/logging-proxy.js
@@ -243,6 +243,21 @@ class LoggingProxy {
             return;
         }
         try {
+            if (component !== algorunnerComponent) {
+                fs.readFile(logFilePath, 'utf8', (err, data) => {
+                    if (err) {
+                        log.error(`Error reading initial file logs: ${err.message}`, { component });
+                    }
+                    else {
+                        const lines = data.split('\n');
+                        lines.forEach(line => {
+                            if (line.trim()) {
+                                this._handleLogMessage(line, component);
+                            }
+                        });
+                    }
+                });
+            }
             const tail = new Tail(logFilePath, { fromBeginning: true });
             tail.on('line', (line) => {
                 this._handleLogMessage(line, component);
@@ -272,7 +287,7 @@ class LoggingProxy {
     _handleLogMessage(line, component) {
         const { logMessage, stream, internalLog } = this._getLogMessage(line);
         if (stream === 'stderr') {
-            log.info(`${logMessage}`, { component, ...internalLog });
+            log.error(`${logMessage}`, { component, ...internalLog });
         }
         else {
             log.info(`${logMessage}`, { component, ...internalLog });

--- a/core/worker/lib/algorithm-logging/logging-proxy.js
+++ b/core/worker/lib/algorithm-logging/logging-proxy.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const Logger = require('@hkube/logger');
 const { Tail } = require('tail');
 const algorunnerComponent = require('../consts').Components.ALGORUNNER;
+const workerComponent = require('../consts').Components.WORKER;
 const kubernetes = require('../helpers/kubernetes');
 
 const DELAY = 2;
@@ -32,7 +33,7 @@ class LoggingProxy {
     async init(options) {
         log = Logger.GetLogFromContainer();
         if (!options?.algorunnerLogging) {
-            log.warning('Logging proxy not started.', { component: algorunnerComponent });
+            log.warning('Logging proxy not started.', { component: workerComponent });
             return;
         }
         if (await this._initAlgorunnerLogFilePath(options)) return; // true if failed
@@ -64,12 +65,12 @@ class LoggingProxy {
             containerName: ALGORITHM_CONTAINER
         });
         if (disable || !logFileName || !baseLogsPath) {
-            log.warning('Algorunner logging proxy not started.', { component: algorunnerComponent });
+            log.warning('Algorunner logging proxy not started.', { component: workerComponent });
             return true;
         }
 
         this._algorunnerLogFilePath = path.join(baseLogsPath, logFileName);
-        log.info(`reading algorunner logs from host path ${this._algorunnerLogFilePath}`, { component: algorunnerComponent });
+        log.info(`reading algorunner logs from host path ${this._algorunnerLogFilePath}`, { component: workerComponent });
         return false;
     }
 
@@ -103,12 +104,11 @@ class LoggingProxy {
                 containerName: carName
             });
             if (disable || !logFileName || !baseLogsPath) {
-                // log.warning(`${carName} logging proxy not started.`, { carName });
-                log.warning(`${carName} logging proxy not started.`, { carName });
+                log.warning(`${carName} logging proxy not started.`, { component: workerComponent });
                 return true;
             }
             this._sideCarLogFilePath[index] = { path: path.join(baseLogsPath, logFileName), carName };
-            log.info(`reading ${carName} logs from host path ${this._sideCarLogFilePath[index].path}`, { carName });
+            log.info(`reading ${carName} logs from host path ${this._sideCarLogFilePath[index].path}`, { component: workerComponent });
             return false;
         });
         return failed;

--- a/core/worker/lib/algorithm-logging/logging-proxy.js
+++ b/core/worker/lib/algorithm-logging/logging-proxy.js
@@ -243,21 +243,6 @@ class LoggingProxy {
             return;
         }
         try {
-            if (component !== algorunnerComponent) {
-                fs.readFile(logFilePath, 'utf8', (err, data) => {
-                    if (err) {
-                        log.throttle.error(`Error reading log file ${logFilePath}: ${err.message}`, { component });
-                    }
-                    else {
-                        const lines = data.split('\n');
-                        lines.forEach(line => {
-                            if (line.trim()) {
-                                this._handleLogMessage(line, component);
-                            }
-                        });
-                    }
-                });
-            }
             const tail = new Tail(logFilePath, { fromBeginning: true });
             tail.on('line', (line) => {
                 this._handleLogMessage(line, component);

--- a/core/worker/lib/algorithm-logging/logging-proxy.js
+++ b/core/worker/lib/algorithm-logging/logging-proxy.js
@@ -246,7 +246,7 @@ class LoggingProxy {
             if (component !== algorunnerComponent) {
                 fs.readFile(logFilePath, 'utf8', (err, data) => {
                     if (err) {
-                        log.error(`Error reading initial file logs: ${err.message}`, { component });
+                        log.throttle.error(`Error reading log file ${logFilePath}: ${err.message}`, { component });
                     }
                     else {
                         const lines = data.split('\n');

--- a/core/worker/lib/algorithm-logging/logging-proxy.js
+++ b/core/worker/lib/algorithm-logging/logging-proxy.js
@@ -12,6 +12,10 @@ let log;
 const ALGORITHM_CONTAINER = 'algorunner';
 const WORKER_CONTAINER = 'worker';
 
+// This class is responsible for proxying the Algorunner and sideCars logs.
+// By doing this, the logs from Algorunner and sideCars are captured and printed into the worker logs.
+// When the logs are printed, they are saved into the logs of the Worker container, and also to ES with the relevant component.
+
 class LoggingProxy {
     /**
      * Initializes the logging proxy by setting up the log file paths for Algorunner and sideCar containers.


### PR DESCRIPTION
Proxy didn't tail the logging of the initial logs - now handling it by reading the file.
Related issue: https://github.com/kube-HPC/hkube/issues/1821

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2057)
<!-- Reviewable:end -->
