### PR TITLE
Duplicate container name fix

### DIFF
--- a/core/api-server/api/rest-api/swagger.json
+++ b/core/api-server/api/rest-api/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "HKube API",
     "description": "HKube RESTful API",
-    "version": "2.8.5",
+    "version": "2.8.6",
     "contact": {
       "email": "hkube.dev@gmail.com"
     },
@@ -7006,11 +7006,6 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "minLength": 1,
-                            "description": "name of the sidecar"
-                          },
                           "container": {
                             "type": "object",
                             "description": "key-value pairs of names and images for containers",
@@ -7681,11 +7676,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8162,11 +8152,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8638,11 +8623,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9170,11 +9150,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9677,11 +9652,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -10148,11 +10118,6 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "name of the sidecar"
-                              },
                               "container": {
                                 "type": "object",
                                 "description": "key-value pairs of names and images for containers",
@@ -17753,11 +17718,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -18287,11 +18247,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -22932,11 +22887,6 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "name of the sidecar"
-                },
                 "container": {
                   "type": "object",
                   "description": "key-value pairs of names and images for containers",
@@ -23553,11 +23503,6 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "name of the sidecar"
-                    },
                     "container": {
                       "type": "object",
                       "description": "key-value pairs of names and images for containers",
@@ -23725,11 +23670,6 @@
       "sideCars": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "name of the sidecar"
-          },
           "container": {
             "type": "object",
             "description": "key-value pairs of names and images for containers",

--- a/core/api-server/lib/service/algorithms.js
+++ b/core/api-server/lib/service/algorithms.js
@@ -270,6 +270,9 @@ class AlgorithmStore {
                 throw new InvalidDataError(`algorithm has invalid workerCustomResources: ${errorOutput.join(', ')}`);
             }
         }
+        if (!this._verifyUniqueSideCarContainerNames(payload)) {
+            throw new InvalidDataError('Sidecar container names must be unique!');
+        }
 
         await this._validateAlgorithm(newAlgorithm);
         const hasDiff = this._compareAlgorithms(newAlgorithm, oldAlgorithm);
@@ -309,6 +312,28 @@ class AlgorithmStore {
             return true;
         }
         return !isEqual(oldAlgorithm, newAlgorithm);
+    }
+
+    /**
+     * Verifies that all container names in the payload are unique.
+     *
+     * @param {Object} payload - The payload containing sideCars data.
+     * @param {Array} payload.sideCars - Array of sidecar objects.
+     * @returns {boolean} - Returns `true` if all container names are unique, otherwise `false`.
+     */
+    _verifyUniqueSideCarContainerNames(payload) {
+        if (!payload.sideCars) return true;
+        const containerNames = [];
+        return payload.sideCars.every(sideCar => {
+            if (sideCar.container && sideCar.container.name) {
+                const containerName = sideCar.container.name;
+                if (containerNames.includes(containerName)) {
+                    return false;
+                }
+                containerNames.push(containerName);
+            }
+            return true;
+        });
     }
 
     _resolveType(payload, file) {

--- a/core/api-server/tests/algorithms-store.js
+++ b/core/api-server/tests/algorithms-store.js
@@ -1014,6 +1014,39 @@ describe('Store/Algorithms', () => {
                 expect(response.body).to.not.have.property('downloadFileExt');
                 expect(response.body).to.not.have.property('nodeSelector');
             });
+            it('should throw validation error if sidecar container names are not unique', async () => {
+                const url = 'https://github.com/hkube/my.git.foo.bar';
+                const body = {
+                    name: uuid(),
+                    gitRepository: {
+                        url
+                    },
+                    env: 'nodejs',
+                    type: 'Git',
+                    sideCars: [
+                        {
+                            container: {
+                                name: 'my-container-1',
+                                image: 'nginx'
+                            }
+                        },
+                        {
+                            container: {
+                                name: 'my-container-1',
+                                image: 'redis'
+                            }
+                        }
+                    ]
+                };
+                const options = {
+                    uri: applyPath,
+                    body: { payload: JSON.stringify(body) }
+                };
+                const response = await request(options);
+                expect(response.body).to.have.property('error');
+                expect(response.body.error.code).to.equal(HttpStatus.StatusCodes.BAD_REQUEST);
+                expect(response.body.error.message).to.contain('Sidecar container names must be unique!');
+            });
         });
         describe('labels and annotations', () => {
             it('should throw validation error of invalid labels key', async () => {

--- a/core/datasources-service/api/rest-api/swagger.json
+++ b/core/datasources-service/api/rest-api/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "HKube API",
     "description": "HKube RESTful API",
-    "version": "2.8.5",
+    "version": "2.8.6",
     "contact": {
       "email": "hkube.dev@gmail.com"
     },
@@ -7006,11 +7006,6 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "minLength": 1,
-                            "description": "name of the sidecar"
-                          },
                           "container": {
                             "type": "object",
                             "description": "key-value pairs of names and images for containers",
@@ -7681,11 +7676,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8162,11 +8152,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8638,11 +8623,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9170,11 +9150,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9677,11 +9652,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -10148,11 +10118,6 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "name of the sidecar"
-                              },
                               "container": {
                                 "type": "object",
                                 "description": "key-value pairs of names and images for containers",
@@ -17753,11 +17718,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -18287,11 +18247,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -22932,11 +22887,6 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "name of the sidecar"
-                },
                 "container": {
                   "type": "object",
                   "description": "key-value pairs of names and images for containers",
@@ -23553,11 +23503,6 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "name of the sidecar"
-                    },
                     "container": {
                       "type": "object",
                       "description": "key-value pairs of names and images for containers",
@@ -23725,11 +23670,6 @@
       "sideCars": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "name of the sidecar"
-          },
           "container": {
             "type": "object",
             "description": "key-value pairs of names and images for containers",

--- a/core/gc-service/api/rest-api/swagger.json
+++ b/core/gc-service/api/rest-api/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "HKube API",
     "description": "HKube RESTful API",
-    "version": "2.8.5",
+    "version": "2.8.6",
     "contact": {
       "email": "hkube.dev@gmail.com"
     },
@@ -7006,11 +7006,6 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "minLength": 1,
-                            "description": "name of the sidecar"
-                          },
                           "container": {
                             "type": "object",
                             "description": "key-value pairs of names and images for containers",
@@ -7681,11 +7676,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8162,11 +8152,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8638,11 +8623,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9170,11 +9150,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9677,11 +9652,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -10148,11 +10118,6 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "name of the sidecar"
-                              },
                               "container": {
                                 "type": "object",
                                 "description": "key-value pairs of names and images for containers",
@@ -17753,11 +17718,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -18287,11 +18247,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -22932,11 +22887,6 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "name of the sidecar"
-                },
                 "container": {
                   "type": "object",
                   "description": "key-value pairs of names and images for containers",
@@ -23553,11 +23503,6 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "name of the sidecar"
-                    },
                     "container": {
                       "type": "object",
                       "description": "key-value pairs of names and images for containers",
@@ -23725,11 +23670,6 @@
       "sideCars": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "name of the sidecar"
-          },
           "container": {
             "type": "object",
             "description": "key-value pairs of names and images for containers",

--- a/core/openapi-spec/swagger.json
+++ b/core/openapi-spec/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "HKube API",
     "description": "HKube RESTful API",
-    "version": "2.8.5",
+    "version": "2.8.6",
     "contact": {
       "email": "hkube.dev@gmail.com"
     },
@@ -7006,11 +7006,6 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "minLength": 1,
-                            "description": "name of the sidecar"
-                          },
                           "container": {
                             "type": "object",
                             "description": "key-value pairs of names and images for containers",
@@ -7681,11 +7676,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8162,11 +8152,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8638,11 +8623,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9170,11 +9150,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9677,11 +9652,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -10148,11 +10118,6 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "name of the sidecar"
-                              },
                               "container": {
                                 "type": "object",
                                 "description": "key-value pairs of names and images for containers",
@@ -17753,11 +17718,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -18287,11 +18247,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -22932,11 +22887,6 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "name of the sidecar"
-                },
                 "container": {
                   "type": "object",
                   "description": "key-value pairs of names and images for containers",
@@ -23553,11 +23503,6 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "name of the sidecar"
-                    },
                     "container": {
                       "type": "object",
                       "description": "key-value pairs of names and images for containers",
@@ -23725,11 +23670,6 @@
       "sideCars": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "name of the sidecar"
-          },
           "container": {
             "type": "object",
             "description": "key-value pairs of names and images for containers",

--- a/core/openapi-spec/swagger/definitions/algorithms/sideCars.yaml
+++ b/core/openapi-spec/swagger/definitions/algorithms/sideCars.yaml
@@ -1,9 +1,5 @@
 type: object
 properties:
-  name:
-    type: string
-    minLength: 1
-    description: name of the sidecar
   container:
     type: object
     description: key-value pairs of names and images for containers

--- a/core/pipeline-driver-queue/api/rest-api/swagger.json
+++ b/core/pipeline-driver-queue/api/rest-api/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "HKube API",
     "description": "HKube RESTful API",
-    "version": "2.8.5",
+    "version": "2.8.6",
     "contact": {
       "email": "hkube.dev@gmail.com"
     },
@@ -7006,11 +7006,6 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "minLength": 1,
-                            "description": "name of the sidecar"
-                          },
                           "container": {
                             "type": "object",
                             "description": "key-value pairs of names and images for containers",
@@ -7681,11 +7676,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8162,11 +8152,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -8638,11 +8623,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9170,11 +9150,6 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1,
-                          "description": "name of the sidecar"
-                        },
                         "container": {
                           "type": "object",
                           "description": "key-value pairs of names and images for containers",
@@ -9677,11 +9652,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -10148,11 +10118,6 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string",
-                                "minLength": 1,
-                                "description": "name of the sidecar"
-                              },
                               "container": {
                                 "type": "object",
                                 "description": "key-value pairs of names and images for containers",
@@ -17753,11 +17718,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -18287,11 +18247,6 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "description": "name of the sidecar"
-                            },
                             "container": {
                               "type": "object",
                               "description": "key-value pairs of names and images for containers",
@@ -22932,11 +22887,6 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "name of the sidecar"
-                },
                 "container": {
                   "type": "object",
                   "description": "key-value pairs of names and images for containers",
@@ -23553,11 +23503,6 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "name of the sidecar"
-                    },
                     "container": {
                       "type": "object",
                       "description": "key-value pairs of names and images for containers",
@@ -23725,11 +23670,6 @@
       "sideCars": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "name of the sidecar"
-          },
           "container": {
             "type": "object",
             "description": "key-value pairs of names and images for containers",

--- a/core/task-executor/lib/jobs/jobCreator.js
+++ b/core/task-executor/lib/jobs/jobCreator.js
@@ -352,7 +352,7 @@ const applySidecars = (inputSpec, customSideCars = [], clusterOptions = {}) => {
         }
         spec = applySidecar({ container: scContainer, volumes, volumeMounts, environments }, spec);
     }
-    customSideCars.forEach(sideCar => {
+    customSideCars.forEach(sideCar => { // Sidecar user-feature
         spec = applySidecar(sideCar, spec);
     });
     return spec;

--- a/scripts/values-test-template.yml
+++ b/scripts/values-test-template.yml
@@ -7,7 +7,7 @@ global:
       pvc:
         capacity: 50Gi
         name: hkube-storage
-        nfs_root: /nfs/storageclass/test-new
+        nfs_root: /nfs/storageclass/test
         nfs_server: 172.20.45.142
         storage_class: "-"
       dev_pvc:


### PR DESCRIPTION
- Bug fix - Duplicate container names are now blocked when creating a new algorithm.
- Sidecar name is now removed, UI should use container name instead.
- Issue: https://github.com/kube-HPC/hkube/issues/2041

NOTE: No merging allowed until the UI starts using the container name instead of the sidecar name!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2066)
<!-- Reviewable:end -->
