### PR TITLE
now getting all pvc using namespace, and not cluster wide.

### DIFF
--- a/core/task-executor/lib/helpers/kubernetes.js
+++ b/core/task-executor/lib/helpers/kubernetes.js
@@ -135,7 +135,7 @@ class KubernetesApi {
      */
     async getAllPVCNames() {
         try {
-            const pvc = await this._client.pvc.all();
+            const pvc = await this._client.pvc.all(true);
             const names = pvc.body.items.map(p => p.metadata.name);
             return names;
         }
@@ -154,7 +154,7 @@ class KubernetesApi {
         */
     async getAllSecretNames() {
         try {
-            const secrets = await this._client.secrets.get({ name: '' });
+            const secrets = await this._client.secrets.get({ secretName: '' });
             const names = secrets.body.items.map(secret => secret.metadata.name);
             return names;
         }

--- a/core/task-executor/tests/mocks/kubernetes-server.mock.js
+++ b/core/task-executor/tests/mocks/kubernetes-server.mock.js
@@ -31,7 +31,7 @@ class MockClient {
                     res.json(nodes);
                     return;
                 }
-                if (req.url === '/api/v1/persistentvolumeclaims') {
+                if (req.url === '/api/v1/namespaces/default/persistentvolumeclaims/') {
                     res.json(persistentVolumeClaim);
                     return;
                 }


### PR DESCRIPTION
Previously, we fetched all PVCs names cluster wide.
Now, we fetch it on namespace level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2134)
<!-- Reviewable:end -->
