### PR TITLE
Self signed certificate for keycloak with minikube

### DIFF
--- a/core/api-server/api/graphql/graphql-server.js
+++ b/core/api-server/api/graphql/graphql-server.js
@@ -18,7 +18,7 @@ const buildContext = (req, keycloak) => {
         if (!keycloak) return true; // Bypass if auth is disabled
         if (!user) throw new AuthenticationError('Unauthorized: Missing or invalid token', StatusCodes.UNAUTHORIZED);
         if (!requiredRoles || requiredRoles.length === 0) return true; // No role restriction
-        return requiredRoles.every(role => userRoles.includes(role)); // Check if user has a required role
+        return requiredRoles.every(role => userRoles.includes(role)); // Check if user has all required roles
     };
 
     const context = { checkPermission, ...req };

--- a/core/api-server/config/main/config.base.js
+++ b/core/api-server/config/main/config.base.js
@@ -219,7 +219,7 @@ config.keycloak = {
     clientSecret: process.env.KC_CLIENT_SECRET || '4q2NZlxDJXcm01p3dAfL8eqVWkmb1HpL',
     authServerUrl: process.env.KC_URL || 'https://cicd.hkube.org/hkube/keycloak',
     defaultUserAuditingName: process.env.KC_DEFAULT_USER_AUDITING_NAME || 'defaultUser',
-    allowSelfSignedCert: formatter.parseBool(process.env.ALLOW_SELF_SIGNED_CERT, false),
+    allowInsecureTLS: process.env.NODE_TLS_REJECT_UNAUTHORIZED === "0",
 }
 
 module.exports = config;

--- a/core/api-server/config/main/config.base.js
+++ b/core/api-server/config/main/config.base.js
@@ -219,6 +219,7 @@ config.keycloak = {
     clientSecret: process.env.KC_CLIENT_SECRET || '4q2NZlxDJXcm01p3dAfL8eqVWkmb1HpL',
     authServerUrl: process.env.KC_URL || 'https://cicd.hkube.org/hkube/keycloak',
     defaultUserAuditingName: process.env.KC_DEFAULT_USER_AUDITING_NAME || 'defaultUser',
+    isSelfSigned: process.env.IS_SELF_SIGNED || false,
 }
 
 module.exports = config;

--- a/core/api-server/config/main/config.base.js
+++ b/core/api-server/config/main/config.base.js
@@ -219,7 +219,7 @@ config.keycloak = {
     clientSecret: process.env.KC_CLIENT_SECRET || '4q2NZlxDJXcm01p3dAfL8eqVWkmb1HpL',
     authServerUrl: process.env.KC_URL || 'https://cicd.hkube.org/hkube/keycloak',
     defaultUserAuditingName: process.env.KC_DEFAULT_USER_AUDITING_NAME || 'defaultUser',
-    allowSelfSignedCert: process.env.ALLOW_SELF_SIGNED_CERT || false,
+    allowSelfSignedCert: formatter.parseBool(process.env.ALLOW_SELF_SIGNED_CERT, false),
 }
 
 module.exports = config;

--- a/core/api-server/config/main/config.base.js
+++ b/core/api-server/config/main/config.base.js
@@ -219,7 +219,7 @@ config.keycloak = {
     clientSecret: process.env.KC_CLIENT_SECRET || '4q2NZlxDJXcm01p3dAfL8eqVWkmb1HpL',
     authServerUrl: process.env.KC_URL || 'https://cicd.hkube.org/hkube/keycloak',
     defaultUserAuditingName: process.env.KC_DEFAULT_USER_AUDITING_NAME || 'defaultUser',
-    isSelfSigned: process.env.IS_SELF_SIGNED || false,
+    allowSelfSignedCert: process.env.ALLOW_SELF_SIGNED_CERT || false,
 }
 
 module.exports = config;

--- a/core/api-server/lib/service/keycloak.js
+++ b/core/api-server/lib/service/keycloak.js
@@ -15,7 +15,6 @@ class KeycloakMiddleware {
 
     async init(options) {
         this._options = options.keycloak;
-        this._isSelfSigned = options.isSelfSigned;
         log = Logger.GetLogFromContainer();
         log.info('Initializing Keycloak middleware...', { component });
 
@@ -35,7 +34,7 @@ class KeycloakMiddleware {
                 const realmInfoUrl = `${this._options.authServerUrl}/realms/${this._options.realm}`;
                 // Conditionally create https agent to trust self-signed certs
                 const axiosOptions = {};
-                if (this._isSelfSigned) {
+                if (this._options.allowSelfSignedCert) {
                     axiosOptions.httpsAgent = new https.Agent({
                         rejectUnauthorized: false
                     });

--- a/core/api-server/lib/service/keycloak.js
+++ b/core/api-server/lib/service/keycloak.js
@@ -32,9 +32,9 @@ class KeycloakMiddleware {
             try {
                 // Validate realm configuration by fetching the realm info
                 const realmInfoUrl = `${this._options.authServerUrl}/realms/${this._options.realm}`;
-                // Conditionally create https agent to trust self-signed certs
                 const axiosOptions = {};
                 if (this._options.allowSelfSignedCert) {
+                    // Create https agent to trust self-signed certs
                     axiosOptions.httpsAgent = new https.Agent({
                         rejectUnauthorized: false
                     });

--- a/core/api-server/lib/service/keycloak.js
+++ b/core/api-server/lib/service/keycloak.js
@@ -33,7 +33,7 @@ class KeycloakMiddleware {
                 // Validate realm configuration by fetching the realm info
                 const realmInfoUrl = `${this._options.authServerUrl}/realms/${this._options.realm}`;
                 const axiosOptions = {};
-                if (this._options.allowSelfSignedCert) {
+                if (this._options.allowInsecureTLS) {
                     // Create https agent to trust self-signed certs
                     axiosOptions.httpsAgent = new https.Agent({
                         rejectUnauthorized: false

--- a/core/api-server/lib/service/keycloak.js
+++ b/core/api-server/lib/service/keycloak.js
@@ -15,8 +15,7 @@ class KeycloakMiddleware {
 
     async init(options) {
         this._options = options.keycloak;
-        // this._dockerRegistry = options.build_secret?.docker_registry; // TODO - make this configurable
-        this._dockerRegistry = 'registry.minikube'; // For testing purposes, set to 'registry.minikube'
+        this._isSelfSigned = options.isSelfSigned;
         log = Logger.GetLogFromContainer();
         log.info('Initializing Keycloak middleware...', { component });
 
@@ -36,7 +35,7 @@ class KeycloakMiddleware {
                 const realmInfoUrl = `${this._options.authServerUrl}/realms/${this._options.realm}`;
                 // Conditionally create https agent to trust self-signed certs
                 const axiosOptions = {};
-                if (this._dockerRegistry === 'registry.minikube') {
+                if (this._isSelfSigned) {
                     axiosOptions.httpsAgent = new https.Agent({
                         rejectUnauthorized: false
                     });

--- a/core/api-server/tests/keycloak.js
+++ b/core/api-server/tests/keycloak.js
@@ -1,0 +1,66 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const axios = require('axios');
+const https = require('https');
+const KeycloakConnect = require('keycloak-connect');
+
+const KeycloakMiddleware = require('../lib/service/keycloak');
+
+describe('Keycloak Middleware', () => {
+    const sandbox = sinon.createSandbox();
+    const dummyRealmResponse = { data: { realm: 'test-realm' } };
+
+    beforeEach(() => {
+        sandbox.stub(KeycloakConnect.prototype, 'protect').returns(() => {});
+        sandbox.stub(axios, 'get').resolves(dummyRealmResponse);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    after(() => {
+        KeycloakMiddleware._options.enabled = false;
+    });
+
+    it('should trust self-signed certificates when allowInsecureTLS is true', async () => {
+        const httpsSpy = sandbox.spy(https, 'Agent');
+
+        await KeycloakMiddleware.init({
+            keycloak: {
+                enabled: true,
+                clientId: 'test-client',
+                clientSecret: 'dummy-secret',
+                realm: 'test-realm',
+                authServerUrl: 'https://my-local-keycloak',
+                allowInsecureTLS: true,
+                defaultUserAuditingName: 'defaultUser'
+            }
+        });
+
+        expect(httpsSpy.calledWithMatch({ rejectUnauthorized: false })).to.equal(true);
+        expect(axios.get.calledWithMatch(
+            'https://my-local-keycloak/realms/test-realm',
+            sinon.match.has('httpsAgent', sinon.match.instanceOf(https.Agent))
+        )).to.equal(true);
+    });
+
+    it('should NOT use https.Agent when allowInsecureTLS is false', async () => {
+        await KeycloakMiddleware.init({
+            keycloak: {
+                enabled: true,
+                clientId: 'test-client',
+                clientSecret: 'dummy-secret',
+                realm: 'test-realm',
+                authServerUrl: 'https://my-local-keycloak',
+                allowInsecureTLS: false,
+                defaultUserAuditingName: 'defaultUser'
+            }
+        });
+
+        expect(axios.get.calledWith(
+            'https://my-local-keycloak/realms/test-realm',
+            {}
+        )).to.equal(true);
+    });
+});


### PR DESCRIPTION
Now api-server supports self signed certificate when running on minikube.
This PR is depended on the following helm PR, since it works when an environment variable is defined under api-server pod (`NODE_TLS_REJECT_UNAUTHORIZED`) - [Helm PR](https://github.com/kube-HPC/helm/pull/141)
Related issue - https://github.com/kube-HPC/hkube/issues/2131

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2174)
<!-- Reviewable:end -->
