### PR TITLE
Worker get no status double hot workers

### DIFF
--- a/core/worker/bootstrap.js
+++ b/core/worker/bootstrap.js
@@ -17,7 +17,6 @@ const modules = [
     require('./lib/boards/boards.js'),
     require('./lib/states/stateManager.js'),
     require('./lib/states/stateAdapter.js'),
-    require('./lib/algorithm-communication/workerCommunication.js'),
     require('./lib/consumer/JobConsumer.js'),
     require('./lib/producer/producer.js'),
     require('./lib/helpers/kubernetes.js'),
@@ -53,6 +52,7 @@ class Bootstrap {
                 await m.init(main, log);
             }
             await worker.init();
+            require('./lib/algorithm-communication/workerCommunication.js').init(main, log);
 
             return main;
         }

--- a/core/worker/lib/states/stateAdapter.js
+++ b/core/worker/lib/states/stateAdapter.js
@@ -6,7 +6,7 @@ const dbConnect = require('@hkube/db');
 const Logger = require('@hkube/logger');
 const { cacheResults } = require('../utils');
 const { getDatasourcesInUseFolder } = require('../helpers/pathUtils');
-const { EventMessages, Components, jobStatus, workerCommands } = require('../consts');
+const { EventMessages, Components, jobStatus, workerCommands, workerStates } = require('../consts');
 const component = Components.ETCD;
 let log;
 
@@ -41,7 +41,7 @@ class StateAdapter extends EventEmitter {
         this._tasksQueue = asyncQueue((task, callback) => {
             this._etcd.jobs.tasks.set(task).then(r => callback(null, r)).catch(e => callback(e));
         }, 1);
-        await this._etcd.discovery.register({ data: this._discoveryInfo, ttl: this._heartBeatTTL });
+        await this._etcd.discovery.register({ data: { ...this._discoveryInfo, workerStatus: workerStates.bootstrap }, ttl: this._heartBeatTTL });
         log.info(`initializing etcd with options: ${JSON.stringify(options.etcd)}`, { component });
         log.info(`registering worker discovery for id ${this._workerId}`, { component });
         await this.watchWorkerStates();


### PR DESCRIPTION
Fixed few bugs:

- worker starts with no state (now starts with bootstrap) 
- worker communication with algorunner fixed - was initlized before all events were registered, now fixed (caused problems when wrapper finished initlizing before worker, and the events were not triggered at the worker part)
- bootstrapped workers are now handled in task-executor - caused two workers to launch when 1 was requested.

No issue related.