### PR TITLE
filtering jobs without job id (#2256)

### DIFF
--- a/core/api-server/lib/service/execution.js
+++ b/core/api-server/lib/service/execution.js
@@ -273,7 +273,9 @@ class ExecutionService {
 
     async getRunningPipelines() {
         const list = await stateManager.searchJobs({ hasResult: false, fields: { jobId: true, pipeline: true } });
-        return list.map(l => ({ jobId: l.jobId, ...l.pipeline }));
+        return list
+            .filter(job => job.jobId)
+            .map(job => ({ jobId: job.jobId, ...job.pipeline }));
     }
 
     async getActivePipelines({ status, raw } = {}) {


### PR DESCRIPTION
Applied patch - filtering out jobs without jobId, so an empty list will be returned.
This bug was fixed with this issue - https://github.com/kube-HPC/hkube/issues/2246
Issue for this PR - https://github.com/kube-HPC/hkube/issues/2263

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2265)
<!-- Reviewable:end -->
