### PR TITLE
Fixed problem with tests

### DIFF
--- a/core/trigger-service/tests/mocks/pipelines.js
+++ b/core/trigger-service/tests/mocks/pipelines.js
@@ -1,12 +1,16 @@
-[
+const { uid: uid } = require('@hkube/uid');
+
+const pipelineTriggeredThree = `pipeline_triggered_three_${uid(6)}`
+
+const pipelines = [
     {
-        "name": "simple"
+        "name": `simple_${uid(6)}`
     },
     {
-        "name": "batch"
+        "name": `batch_${uid(6)}`
     },
     {
-        "name": "simple_cron_trigger",
+        "name": `simple_cron_trigger_${uid(6)}`,
         "triggers": {
             "cron": {
                 "pattern": "*/1 * * * * *",
@@ -15,7 +19,7 @@
         }
     },
     {
-        "name": "invalid_cron_trigger",
+        "name": `invalid_cron_trigger_${uid(6)}`,
         "triggers": {
             "cron": {
                 "pattern": "Im invalid cron",
@@ -24,7 +28,7 @@
         }
     },
     {
-        "name": "simple_pipelines_trigger",
+        "name": `simple_pipelines_trigger_${uid(6)}`,
         "triggers": {
             "pipelines": [
                 "xxx"
@@ -32,7 +36,7 @@
         }
     },
     {
-        "name": "trigger-4",
+        "name": `trigger-4_${uid(6)}`,
         "triggers": {
             "pipelines": [
                 "test-not-called"
@@ -40,31 +44,33 @@
         }
     },
     {
-        "name": "trigger-1",
+        "name": `trigger-1_${uid(6)}`,
         "triggers": {
             "pipelines": [
-                "pipeline_triggered_three"
+                pipelineTriggeredThree
             ]
         }
     },
     {
-        "name": "trigger-2",
+        "name": `trigger-2_${uid(6)}`,
         "triggers": {
             "pipelines": [
-                "pipeline_triggered_three"
+                pipelineTriggeredThree
             ]
         }
     },
     {
-        "name": "trigger-3",
+        "name": `trigger-3_${uid(6)}`,
         "triggers": {
             "pipelines": [
-                "pipeline_triggered_three",
+                pipelineTriggeredThree,
                 "test_pl"
             ]
         }
     },
     {
-        "name": "pipeline_triggered_three"
+        "name": pipelineTriggeredThree
     }
 ]
+
+module.exports = pipelines;

--- a/core/trigger-service/tests/test.js
+++ b/core/trigger-service/tests/test.js
@@ -8,7 +8,7 @@ const pipelineProducer = require('../lib/pipelines/pipeline-producer');
 const { cronTrigger, pipelineTrigger } = require('../lib/triggers');
 const bootstrap = require('../bootstrap');
 const Trigger = require('../lib/triggers/Trigger');
-const pipelines = require('./mocks/pipelines.json');
+const pipelines = require('./mocks/pipelines');
 const { Triggers } = require('../lib/consts');
 const delay = require('await-delay');
 
@@ -25,35 +25,35 @@ describe('test', () => {
             cronTrigger._crons.clear();
         });
         it('should get cron job map', () => {
-            const pipeline = pipelines.find(p => p.name === 'simple_cron_trigger');
+            const pipeline = pipelines.find(p => p.name.startsWith('simple_cron_trigger'));
             cronTrigger._updateTrigger(new Trigger(pipeline));
             const cron = cronTrigger._crons.get(pipeline.name);
             expect(cron.pattern).to.equal(pipeline.triggers.cron.pattern);
         });
         it('should not change the cron jobs size when no cron', () => {
-            const pipeline = pipelines.find(p => p.name === 'simple');
+            const pipeline = pipelines.find(p => p.name.startsWith('simple'));
             storeManager.emit('change', new Trigger(pipeline));
             expect(cronTrigger._crons.size).to.equal(0)
         });
         it('should not change the cron jobs size when same exist cron', () => {
-            const pipeline = pipelines.find(p => p.name === 'simple_cron_trigger');
+            const pipeline = pipelines.find(p => p.name.startsWith('simple_cron_trigger'));
             storeManager.emit('change', new Trigger(pipeline));
             expect(cronTrigger._crons.size).to.equal(1)
         });
         it('should increase the cron jobs size by one', () => {
-            const cron = pipelines.find(p => p.name === 'simple_cron_trigger');
+            const cron = pipelines.find(p => p.name.startsWith('simple_cron_trigger'));
             const pipeline = { ...cron, name: 'new_simple_cron_trigger' };
             storeManager.emit('change', new Trigger(pipeline));
             expect(cronTrigger._crons.size).to.equal(1)
         });
         it('should decrease the cron jobs size when invalid cron pattern', () => {
-            const pipeline = pipelines.find(p => p.name === 'invalid_cron_trigger');
+            const pipeline = pipelines.find(p => p.name.startsWith('invalid_cron_trigger'));
             storeManager.emit('change', new Trigger(pipeline));
             expect(cronTrigger._crons.size).to.equal(0)
         });
         it('should run cron job', () => {
             const clock = sinon.useFakeTimers();
-            const pipeline = pipelines.find(p => p.name === 'simple_cron_trigger');
+            const pipeline = pipelines.find(p => p.name.startsWith('simple_cron_trigger'));
             const spy = sinon.spy(cronTrigger, "_onTick");
             storeManager.emit('change', new Trigger(pipeline));
             clock.tick(1000);
@@ -64,9 +64,10 @@ describe('test', () => {
     });
     describe('PipelineTrigger', () => {
         it('should trigger 3 pipelines', async () => {
+            const { name } = pipelines.find(p => p.name.startsWith('pipeline_triggered_three'));
             const result = {
                 data: 'data',
-                pipeline: 'pipeline_triggered_three',
+                pipeline: name,
                 jobId: 'jobId'
             }
             const spyAdd = sinon.spy(triggerQueue, "addTrigger");


### PR DESCRIPTION
Since there were no indices in DB, the same pipeline name was inserted causing for multiple pipelines to exist.
This caused the trigger to call pipeline abcde (example), which was inserted again and again every time the tests ran thus causing a test result to be number of abcde matches in db * 3.
This should not be permitted, and is permitted because the init of db is not with a flag called createIndices set to true.
So, now we generate a new pipeline name for every pipeline for every test.

Issue - https://github.com/kube-HPC/hkube/issues/2310

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2314)
<!-- Reviewable:end -->
