### PR TITLE
buster EOL fix for algorithm-builder

### DIFF
--- a/core/algorithm-builder/dockerfile/Dockerfile
+++ b/core/algorithm-builder/dockerfile/Dockerfile
@@ -9,6 +9,15 @@ ARG BASE_PRIVATE_REGISTRY=""
 FROM ${BASE_PRIVATE_REGISTRY}hkube/base-node:v2.0.1-buster
 LABEL maintainer="hkube.dev@gmail.com"
 
+RUN set -eux; \
+    sed -i 's|deb.debian.org/debian|archive.debian.org/debian|g' /etc/apt/sources.list; \
+    sed -i 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' /etc/apt/sources.list; \
+    sed -i '/stretch-updates/d' /etc/apt/sources.list; \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until; \
+    apt-get update -o Acquire::AllowInsecureRepositories=true; \
+    apt-get install -y --no-install-recommends git gettext-base; \
+    rm -rf /var/lib/apt/lists/*
+
 RUN apt update && apt install -y git gettext-base && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /hkube/algorithm-builder
 WORKDIR /hkube/algorithm-builder


### PR DESCRIPTION
fix: update Debian sources in Dockerfile to support EOL for buster
kube-HPC/hkube/issues/2341

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2342)
<!-- Reviewable:end -->
