### PR TITLE
Update job query parameters to use 'tags' array

### DIFF
--- a/core/api-server/api/graphql/queries/database-querier.js
+++ b/core/api-server/api/graphql/queries/database-querier.js
@@ -95,7 +95,7 @@ class DatabaseQuerier extends Events {
         return { experimentName, jobs };
     }
 
-    async getJobs({ experimentName, pipelineName, pipelineType, pipelineStatus, algorithmName, datesRange, user, action, cursor, pageNum, sort, limit = MAX_ITEMS, tag }, searchByPrefix = false) {
+    async getJobs({ experimentName, pipelineName, pipelineType, pipelineStatus, algorithmName, datesRange, user, action, cursor, pageNum, sort, limit = MAX_ITEMS, tags }, searchByPrefix = false) {
         const query = {
             experimentName,
             pipelineName,
@@ -105,7 +105,7 @@ class DatabaseQuerier extends Events {
             datesRange,
             user,
             action,
-            tags: tag ? [tag] : undefined
+            tags
         };
         const jobs = await this._db.jobs.searchApi({
             query,

--- a/core/api-server/api/graphql/schemas/job-schema.js
+++ b/core/api-server/api/graphql/schemas/job-schema.js
@@ -256,7 +256,7 @@ const jobTypeDefs = gql`
       datesRange: Range
       cursor: String
       limit: Int
-      tag: String
+      tags: [String]
     ): AggregatedJobs
 
     job(id: String!): Job


### PR DESCRIPTION
Update job query parameters to use 'tags' array instead of single 'tag' string
Resolves #2353
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/hkube/2414)
<!-- Reviewable:end -->
